### PR TITLE
Fix mobile build by stubbing html

### DIFF
--- a/lib/html_stub.dart
+++ b/lib/html_stub.dart
@@ -1,0 +1,14 @@
+class Blob {
+  Blob([List<dynamic>? data, String? type]);
+}
+
+class Url {
+  static String createObjectUrlFromBlob(Blob blob) => '';
+  static void revokeObjectUrl(String url) {}
+}
+
+class AnchorElement {
+  AnchorElement({String? href});
+  void setAttribute(String name, String value) {}
+  void click() {}
+}

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -12,7 +12,8 @@ import 'dart:convert';
 import 'dart:ui' as ui; // For TextDirection
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:share_plus/share_plus.dart';
-import 'dart:html' as html;
+import '../../html_stub.dart'
+    if (dart.library.html) 'dart:html' as html;
 
 // --- PDF and Path Provider Imports ---
 import 'package:pdf/pdf.dart';


### PR DESCRIPTION
## Summary
- stub out dart:html APIs for non-web platforms
- use conditional import for project details page

## Testing
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840950688a0832abb57d25d00c5c8cd