### PR TITLE
Add project employee tracking

### DIFF
--- a/lib/pages/engineer/employees_tab.dart
+++ b/lib/pages/engineer/employees_tab.dart
@@ -60,13 +60,14 @@ class EmployeesTab extends StatelessWidget {
     );
   }
 
-  Future<void> _recordAttendance(BuildContext context, String employeeId, String type) async {
+  Future<void> _recordAttendance(BuildContext context, String employeeId, String type, {String? projectId}) async {
     try {
       await FirebaseFirestore.instance.collection('attendance').add({
         'userId': employeeId,
         'type': type,
         'timestamp': Timestamp.now(),
         'recordedBy': engineerId,
+        if (projectId != null) 'projectId': projectId,
       });
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(


### PR DESCRIPTION
## Summary
- support optional projectId when recording employee attendance
- add new tab in project details to manage employees
- allow engineers to assign employees to phases and track attendance

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a4b16038832aa4e910e023563458