### PR TITLE
Fix PDF image decoding

### DIFF
--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -2009,8 +2009,6 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
                 print('Invalid image bytes for URL $url');
               }
             } catch (e) {
-              fetchedImages[url] = pw.MemoryImage(response.bodyBytes);
-            } catch (e) {
               // If the bytes cannot be decoded into an image, skip this URL
               print('Invalid image data for URL $url: $e');
             }


### PR DESCRIPTION
## Summary
- avoid keeping invalid image data when generating PDFs

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d4e2fa20832aa4567481e1d920f6