### PR TITLE
Add password change settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:engineer_management_system/pages/admin/admin_settings_page.dart'
 import 'package:engineer_management_system/pages/engineer/request_part_page.dart';
 import 'package:engineer_management_system/pages/engineer/meeting_logs_page.dart';
 import 'package:engineer_management_system/pages/admin/admin_meeting_logs_page.dart';
+import 'package:engineer_management_system/pages/common/change_password_page.dart';
 
 // --- ADDITION START ---
 import 'package:engineer_management_system/pages/admin/admin_evaluations_page.dart'; // استيراد صفحة التقييم الجديدة
@@ -113,6 +114,9 @@ class MyApp extends StatelessWidget {
         '/admin/attendance': (context) => const AdminAttendancePage(),
         '/admin/attendance_report': (context) => const AdminAttendanceReportPage(),
         '/notifications': (context) => const NotificationsPage(),
+        '/admin/change_password': (context) => const ChangePasswordPage(role: 'admin'),
+        '/engineer/change_password': (context) => const ChangePasswordPage(role: 'engineer'),
+        '/client/change_password': (context) => const ChangePasswordPage(role: 'client'),
         // New route for requesting parts
         '/engineer/request_part': (context) {
           final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>?;

--- a/lib/pages/admin/admin_dashboard.dart
+++ b/lib/pages/admin/admin_dashboard.dart
@@ -347,7 +347,9 @@ class _AdminDashboardState extends State<AdminDashboard> with TickerProviderStat
           icon: const Icon(Icons.more_vert, color: Colors.white),
           onSelected: (value) {
             switch (value) {
-
+              case 'change_password':
+                Navigator.pushNamed(context, '/admin/change_password');
+                break;
               case 'settings':
                 Navigator.pushNamed(context, '/admin/settings');
                 break;
@@ -357,7 +359,16 @@ class _AdminDashboardState extends State<AdminDashboard> with TickerProviderStat
             }
           },
           itemBuilder: (context) => [
-
+            const PopupMenuItem(
+              value: 'change_password',
+              child: Row(
+                children: [
+                  Icon(Icons.lock_reset, color: AppConstants.primaryColor),
+                  SizedBox(width: 8),
+                  Text('تغيير كلمة المرور'),
+                ],
+              ),
+            ),
             const PopupMenuItem(
               value: 'settings',
               child: Row(

--- a/lib/pages/client/client_home.dart
+++ b/lib/pages/client/client_home.dart
@@ -492,10 +492,40 @@ class _ClientHomeState extends State<ClientHome> with TickerProviderStateMixin {
               )
           ],
         ),
-        IconButton(
-          icon: const Icon(Icons.logout_rounded, color: Colors.white),
-          tooltip: 'تسجيل الخروج',
-          onPressed: _logout,
+        PopupMenuButton<String>(
+          icon: const Icon(Icons.more_vert, color: Colors.white),
+          onSelected: (value) {
+            switch (value) {
+              case 'change_password':
+                Navigator.pushNamed(context, '/client/change_password');
+                break;
+              case 'logout':
+                _logout();
+                break;
+            }
+          },
+          itemBuilder: (context) => [
+            const PopupMenuItem(
+              value: 'change_password',
+              child: Row(
+                children: [
+                  Icon(Icons.lock_reset, color: AppConstants.primaryColor),
+                  SizedBox(width: 8),
+                  Text('تغيير كلمة المرور'),
+                ],
+              ),
+            ),
+            const PopupMenuItem(
+              value: 'logout',
+              child: Row(
+                children: [
+                  Icon(Icons.logout, color: AppConstants.errorColor),
+                  SizedBox(width: 8),
+                  Text('تسجيل الخروج', style: TextStyle(color: AppConstants.errorColor)),
+                ],
+              ),
+            ),
+          ],
         ),
       ],
       bottom: TabBar(

--- a/lib/pages/common/change_password_page.dart
+++ b/lib/pages/common/change_password_page.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../../theme/app_constants.dart';
+
+class ChangePasswordPage extends StatefulWidget {
+  final String role;
+  const ChangePasswordPage({Key? key, required this.role}) : super(key: key);
+
+  @override
+  State<ChangePasswordPage> createState() => _ChangePasswordPageState();
+}
+
+class _ChangePasswordPageState extends State<ChangePasswordPage> {
+  final _currentPasswordController = TextEditingController();
+  final _newPasswordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+  bool _isLoading = false;
+  bool _obscureCurrent = true;
+  bool _obscureNew = true;
+  bool _obscureConfirm = true;
+
+  @override
+  void dispose() {
+    _currentPasswordController.dispose();
+    _newPasswordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _changePassword() async {
+    if (!_formKey.currentState!.validate()) return;
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    setState(() => _isLoading = true);
+    try {
+      final cred = EmailAuthProvider.credential(
+          email: user.email!, password: _currentPasswordController.text.trim());
+      await user.reauthenticateWithCredential(cred);
+      await user.updatePassword(_newPasswordController.text.trim());
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('تم تغيير كلمة المرور بنجاح'),
+            backgroundColor: AppConstants.successColor,
+            behavior: SnackBarBehavior.floating,
+            shape: RoundedRectangleBorder(
+                borderRadius:
+                    BorderRadius.circular(AppConstants.borderRadius / 2)),
+            margin: const EdgeInsets.all(AppConstants.paddingMedium),
+          ),
+        );
+        Navigator.pop(context);
+      }
+    } on FirebaseAuthException catch (e) {
+      _showError(_getFirebaseErrorMessage(e.code));
+    } catch (e) {
+      _showError('حدث خطأ غير متوقع.');
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  void _showError(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: AppConstants.errorColor,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppConstants.borderRadius / 2)),
+        margin: const EdgeInsets.all(AppConstants.paddingMedium),
+      ),
+    );
+  }
+
+  String _getFirebaseErrorMessage(String code) {
+    switch (code) {
+      case 'wrong-password':
+        return 'كلمة المرور الحالية غير صحيحة.';
+      case 'weak-password':
+        return 'كلمة المرور الجديدة ضعيفة جداً.';
+      case 'requires-recent-login':
+        return 'الرجاء تسجيل الدخول مجدداً ثم المحاولة.';
+      default:
+        return 'فشل تغيير كلمة المرور: $code';
+    }
+  }
+
+  Widget _buildTextField({
+    required TextEditingController controller,
+    required String label,
+    required IconData icon,
+    bool obscure = false,
+    required void Function() toggle,
+  }) {
+    return TextFormField(
+      controller: controller,
+      obscureText: obscure,
+      decoration: InputDecoration(
+        labelText: label,
+        prefixIcon: Icon(icon, color: AppConstants.primaryColor),
+        suffixIcon: IconButton(
+          icon: Icon(obscure ? Icons.visibility : Icons.visibility_off,
+              color: AppConstants.textSecondary),
+          onPressed: toggle,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppConstants.borderRadius / 1.5),
+          borderSide:
+              const BorderSide(color: AppConstants.textSecondary, width: 1.5),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppConstants.borderRadius / 1.5),
+          borderSide: const BorderSide(color: AppConstants.primaryColor, width: 2),
+        ),
+      ),
+      validator: (value) {
+        if (value == null || value.isEmpty) {
+          return 'هذا الحقل مطلوب';
+        }
+        return null;
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('تغيير كلمة المرور',
+              style: TextStyle(color: Colors.white)),
+          backgroundColor: AppConstants.primaryColor,
+          flexibleSpace: Container(
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                colors: [AppConstants.primaryColor, AppConstants.primaryLight],
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
+            ),
+          ),
+          centerTitle: true,
+        ),
+        backgroundColor: AppConstants.backgroundColor,
+        body: Padding(
+          padding: const EdgeInsets.all(AppConstants.paddingLarge),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _buildTextField(
+                    controller: _currentPasswordController,
+                    label: 'كلمة المرور الحالية',
+                    icon: Icons.lock_outline,
+                    obscure: _obscureCurrent,
+                    toggle: () => setState(() => _obscureCurrent = !_obscureCurrent)),
+                const SizedBox(height: AppConstants.itemSpacing),
+                _buildTextField(
+                    controller: _newPasswordController,
+                    label: 'كلمة المرور الجديدة',
+                    icon: Icons.lock_open_rounded,
+                    obscure: _obscureNew,
+                    toggle: () => setState(() => _obscureNew = !_obscureNew)),
+                const SizedBox(height: AppConstants.itemSpacing),
+                _buildTextField(
+                    controller: _confirmPasswordController,
+                    label: 'تأكيد كلمة المرور الجديدة',
+                    icon: Icons.lock,
+                    obscure: _obscureConfirm,
+                    toggle: () => setState(() => _obscureConfirm = !_obscureConfirm)),
+                const SizedBox(height: AppConstants.paddingLarge),
+                ElevatedButton.icon(
+                  onPressed: _isLoading
+                      ? null
+                      : () {
+                          if (_newPasswordController.text.trim() !=
+                              _confirmPasswordController.text.trim()) {
+                            _showError('كلمتا المرور غير متطابقتين');
+                            return;
+                          }
+                          _changePassword();
+                        },
+                  icon: _isLoading
+                      ? const SizedBox.shrink()
+                      : const Icon(Icons.save_alt_rounded, color: Colors.white),
+                  label: _isLoading
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 3,
+                            valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                          ),
+                        )
+                      : const Text('حفظ التغيير',
+                          style: TextStyle(color: Colors.white, fontSize: 18)),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppConstants.primaryColor,
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: AppConstants.paddingLarge,
+                        vertical: AppConstants.paddingMedium),
+                    shape: RoundedRectangleBorder(
+                      borderRadius:
+                          BorderRadius.circular(AppConstants.borderRadius / 1.5),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/engineer/engineer_home.dart
+++ b/lib/pages/engineer/engineer_home.dart
@@ -939,10 +939,40 @@ class _EngineerHomeState extends State<EngineerHome> with TickerProviderStateMix
           ],
         ),
         // --- ADDITION END ---
-        IconButton(
-          icon: const Icon(Icons.logout_rounded, color: Colors.white),
-          tooltip: 'تسجيل الخروج',
-          onPressed: _logout,
+        PopupMenuButton<String>(
+          icon: const Icon(Icons.more_vert, color: Colors.white),
+          onSelected: (value) {
+            switch (value) {
+              case 'change_password':
+                Navigator.pushNamed(context, '/engineer/change_password');
+                break;
+              case 'logout':
+                _logout();
+                break;
+            }
+          },
+          itemBuilder: (context) => [
+            const PopupMenuItem(
+              value: 'change_password',
+              child: Row(
+                children: [
+                  Icon(Icons.lock_reset, color: AppConstants.primaryColor),
+                  SizedBox(width: 8),
+                  Text('تغيير كلمة المرور'),
+                ],
+              ),
+            ),
+            const PopupMenuItem(
+              value: 'logout',
+              child: Row(
+                children: [
+                  Icon(Icons.logout, color: AppConstants.errorColor),
+                  SizedBox(width: 8),
+                  Text('تسجيل الخروج', style: TextStyle(color: AppConstants.errorColor)),
+                ],
+              ),
+            ),
+          ],
         ),
       ],
       bottom: TabBar(


### PR DESCRIPTION
## Summary
- add shared change password page
- route admins, engineers, and clients to change password page
- include change password option in each role's menu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847dc595d44832abb6643c3f74bb01d