### PR TITLE
Add Saudi holiday defaults

### DIFF
--- a/lib/pages/admin/admin_holiday_settings_page.dart
+++ b/lib/pages/admin/admin_holiday_settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:engineer_management_system/theme/app_constants.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
+import '../../utils/saudi_holidays.dart';
 import 'dart:ui' as ui;
 
 class AdminHolidaySettingsPage extends StatefulWidget {
@@ -47,10 +48,19 @@ class _AdminHolidaySettingsPageState extends State<AdminHolidaySettingsPage> {
         _selectedWeeklyHolidays
           ..clear()
           ..addAll(List<int>.from(data['weeklyHolidays'] ?? []));
+        final loaded = (data['specialHolidays'] as List<dynamic>? ?? [])
+            .map((d) => DateTime.tryParse(d as String))
+            .whereType<DateTime>()
+            .toList();
         _specialHolidays
           ..clear()
-          ..addAll((data['specialHolidays'] as List<dynamic>? ?? [])
-              .map((d) => DateTime.tryParse(d as String) ?? DateTime.now()));
+          ..addAll(loaded.isEmpty
+              ? saudiOfficialHolidays(DateTime.now().year)
+              : loaded);
+      } else {
+        _specialHolidays
+          ..clear()
+          ..addAll(saudiOfficialHolidays(DateTime.now().year));
       }
     } catch (e) {
       _showFeedbackSnackBar(context, 'فشل تحميل الإعدادات: $e', isError: true);

--- a/lib/pages/admin/admin_settings_page.dart
+++ b/lib/pages/admin/admin_settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:engineer_management_system/theme/app_constants.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
+import '../../utils/saudi_holidays.dart';
 import 'dart:ui' as ui; // For TextDirection
 
 
@@ -78,10 +79,13 @@ class _AdminSettingsPageState extends State<AdminSettingsPage> {
         _selectedWeeklyHolidays
           ..clear()
           ..addAll(List<int>.from(data['weeklyHolidays'] ?? []));
+        final loaded = (data['specialHolidays'] as List<dynamic>? ?? [])
+            .map((d) => DateTime.tryParse(d as String))
+            .whereType<DateTime>()
+            .toList();
         _specialHolidays
           ..clear()
-          ..addAll((data['specialHolidays'] as List<dynamic>? ?? [])
-              .map((d) => DateTime.tryParse(d as String) ?? DateTime.now()));
+          ..addAll(loaded.isEmpty ? saudiOfficialHolidays(DateTime.now().year) : loaded);
       } else {
         _defaultWorkingHoursController.text = '10.0';
         _engineerHourlyRateController.text = '50.0';
@@ -93,9 +97,14 @@ class _AdminSettingsPageState extends State<AdminSettingsPage> {
           'workStartTime': '06:30',
           'workEndTime': '16:30',
           'weeklyHolidays': [],
-          'specialHolidays': [],
+          'specialHolidays': saudiOfficialHolidays(DateTime.now().year)
+              .map((d) => DateFormat('yyyy-MM-dd').format(d))
+              .toList(),
           'lastUpdated': FieldValue.serverTimestamp(),
         });
+        _specialHolidays
+          ..clear()
+          ..addAll(saudiOfficialHolidays(DateTime.now().year));
       }
     } catch (e) {
       if (mounted) {

--- a/lib/utils/saudi_holidays.dart
+++ b/lib/utils/saudi_holidays.dart
@@ -1,0 +1,7 @@
+/// Utility to provide official Saudi Arabia holidays.
+List<DateTime> saudiOfficialHolidays(int year) {
+  return [
+    DateTime(year, 2, 22), // Founding Day
+    DateTime(year, 9, 23), // National Day
+  ];
+}


### PR DESCRIPTION
## Summary
- include utility for Saudi Arabia official holidays
- use official holiday list when loading admin holiday settings
- populate defaults for Saudi holidays in admin settings page

## Testing
- `dart format lib/utils/saudi_holidays.dart lib/pages/admin/admin_holiday_settings_page.dart lib/pages/admin/admin_settings_page.dart`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6847efb93504832a9a3446ca48f45a25