### PR TITLE
Add named recurring Saudi holidays

### DIFF
--- a/lib/models/holiday.dart
+++ b/lib/models/holiday.dart
@@ -1,0 +1,20 @@
+class Holiday {
+  final String name;
+  final DateTime date;
+
+  Holiday({required this.name, required this.date});
+
+  factory Holiday.fromMap(Map<String, dynamic> map) {
+    return Holiday(
+      name: map['name'] ?? '',
+      date: DateTime.tryParse(map['date'] ?? '') ?? DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'date': date.toIso8601String().split('T').first,
+    };
+  }
+}

--- a/lib/pages/admin/admin_holiday_settings_page.dart
+++ b/lib/pages/admin/admin_holiday_settings_page.dart
@@ -3,6 +3,7 @@ import 'package:engineer_management_system/theme/app_constants.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 import '../../utils/saudi_holidays.dart';
+import '../../models/holiday.dart';
 import 'dart:ui' as ui;
 
 class AdminHolidaySettingsPage extends StatefulWidget {
@@ -14,7 +15,7 @@ class AdminHolidaySettingsPage extends StatefulWidget {
 
 class _AdminHolidaySettingsPageState extends State<AdminHolidaySettingsPage> {
   final Set<int> _selectedWeeklyHolidays = {};
-  final List<DateTime> _specialHolidays = [];
+  final List<Holiday> _specialHolidays = [];
 
   final Map<int, String> _weekDays = {
     DateTime.saturday: 'السبت',
@@ -49,8 +50,16 @@ class _AdminHolidaySettingsPageState extends State<AdminHolidaySettingsPage> {
           ..clear()
           ..addAll(List<int>.from(data['weeklyHolidays'] ?? []));
         final loaded = (data['specialHolidays'] as List<dynamic>? ?? [])
-            .map((d) => DateTime.tryParse(d as String))
-            .whereType<DateTime>()
+            .map((d) {
+              if (d is Map<String, dynamic>) {
+                return Holiday.fromMap(d);
+              } else if (d is String) {
+                final parsed = DateTime.tryParse(d);
+                return parsed != null ? Holiday(name: 'عطلة', date: parsed) : null;
+              }
+              return null;
+            })
+            .whereType<Holiday>()
             .toList();
         _specialHolidays
           ..clear()
@@ -82,7 +91,7 @@ class _AdminHolidaySettingsPageState extends State<AdminHolidaySettingsPage> {
         {
           'weeklyHolidays': _selectedWeeklyHolidays.toList(),
           'specialHolidays': _specialHolidays
-              .map((d) => DateFormat('yyyy-MM-dd').format(d))
+              .map((h) => h.toMap())
               .toList(),
           'lastUpdated': FieldValue.serverTimestamp(),
         },
@@ -139,15 +148,12 @@ class _AdminHolidaySettingsPageState extends State<AdminHolidaySettingsPage> {
         const SizedBox(height: AppConstants.paddingSmall),
         Wrap(
           spacing: 8,
-          children: _specialHolidays.map((date) {
-            final label = DateFormat('yyyy-MM-dd').format(date);
+          children: _specialHolidays.map((holiday) {
+            final label = '${holiday.name} - '
+                '${DateFormat('yyyy-MM-dd').format(holiday.date)}';
             return InputChip(
               label: Text(label),
-              onDeleted: () {
-                setState(() {
-                  _specialHolidays.remove(date);
-                });
-              },
+              onDeleted: () => _confirmDeleteHoliday(holiday),
             );
           }).toList(),
         ),
@@ -162,18 +168,50 @@ class _AdminHolidaySettingsPageState extends State<AdminHolidaySettingsPage> {
             );
             if (picked != null) {
               setState(() {
-                if (!_specialHolidays.any((d) => d.year == picked.year && d.month == picked.month && d.day == picked.day)) {
-                  _specialHolidays.add(picked);
+                if (!_specialHolidays.any((h) => h.date.year == picked.year && h.date.month == picked.month && h.date.day == picked.day)) {
+                  _specialHolidays.add(Holiday(name: 'عطلة', date: picked));
                 }
               });
             }
           },
           icon: const Icon(Icons.add, color: Colors.white),
           label: const Text('إضافة تاريخ', style: TextStyle(color: Colors.white)),
-          style: ElevatedButton.styleFrom(backgroundColor: AppConstants.primaryColor),
+      style: ElevatedButton.styleFrom(backgroundColor: AppConstants.primaryColor),
+    ),
+  ],
+);
+}
+
+  Future<void> _confirmDeleteHoliday(Holiday holiday) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppConstants.borderRadius),
         ),
-      ],
+        title: const Text('تأكيد الحذف'),
+        content: Text('هل تريد حذف \u200E${holiday.name}?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('إلغاء'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppConstants.errorColor,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('حذف'),
+          ),
+        ],
+      ),
     );
+    if (confirmed == true) {
+      setState(() {
+        _specialHolidays.remove(holiday);
+      });
+    }
   }
 
   void _showFeedbackSnackBar(BuildContext context, String message, {required bool isError}) {

--- a/lib/pages/engineer/engineer_home.dart
+++ b/lib/pages/engineer/engineer_home.dart
@@ -430,7 +430,14 @@ class _EngineerHomeState extends State<EngineerHome> with TickerProviderStateMix
 
       final weekly = List<int>.from(settings['weeklyHolidays'] ?? []);
       final special = (settings['specialHolidays'] as List<dynamic>? ?? [])
-          .map((d) => DateTime.tryParse(d as String))
+          .map((d) {
+            if (d is Map<String, dynamic>) {
+              return DateTime.tryParse(d['date'] ?? '');
+            } else if (d is String) {
+              return DateTime.tryParse(d);
+            }
+            return null;
+          })
           .whereType<DateTime>()
           .toList();
       final bool isHoliday =

--- a/lib/utils/saudi_holidays.dart
+++ b/lib/utils/saudi_holidays.dart
@@ -1,7 +1,63 @@
-/// Utility to provide official Saudi Arabia holidays.
-List<DateTime> saudiOfficialHolidays(int year) {
+import '../models/holiday.dart';
+
+/// Utility to provide official Saudi Arabia holidays with their names.
+
+const int _islamicEpoch = 1948439; // Julian day of 1 Muharram, year 1 AH.
+
+int _gregorianToJD(int year, int month, int day) {
+  int a = ((14 - month) ~/ 12);
+  int y = year + 4800 - a;
+  int m = month + 12 * a - 3;
+  return day + ((153 * m + 2) ~/ 5) + 365 * y + y ~/ 4 - y ~/ 100 + y ~/ 400 - 32045;
+}
+
+DateTime _jdToGregorian(int jd) {
+  int l = jd + 68569;
+  int n = (4 * l) ~/ 146097;
+  l = l - (146097 * n + 3) ~/ 4;
+  int i = (4000 * (l + 1)) ~/ 1461001;
+  l = l - (1461 * i) ~/ 4 + 31;
+  int j = (80 * l) ~/ 2447;
+  int day = l - (2447 * j) ~/ 80;
+  l = j ~/ 11;
+  int month = j + 2 - 12 * l;
+  int year = 100 * (n - 49) + i + l;
+  return DateTime(year, month, day);
+}
+
+int _islamicToJD(int year, int month, int day) {
+  return day + ((29.5 * (month - 1)).ceil()) + (year - 1) * 354 + ((3 + 11 * year) ~/ 30) + _islamicEpoch - 1;
+}
+
+int _jdToIslamicYear(int jd) {
+  return ((30 * (jd - _islamicEpoch) + 10646) / 10631).floor();
+}
+
+DateTime _islamicToGregorianDate(int year, int month, int day) {
+  int jd = _islamicToJD(year, month, day);
+  return _jdToGregorian(jd);
+}
+
+DateTime _calculateIslamicHoliday(int gregorianYear, int hijriMonth, int hijriDay) {
+  int startYear = _jdToIslamicYear(_gregorianToJD(gregorianYear, 1, 1));
+  DateTime result = _islamicToGregorianDate(startYear, hijriMonth, hijriDay);
+  if (result.year != gregorianYear) {
+    result = _islamicToGregorianDate(startYear + 1, hijriMonth, hijriDay);
+  }
+  return result;
+}
+
+List<Holiday> saudiOfficialHolidays(int year) {
+  final eidFitr = _calculateIslamicHoliday(year, 10, 1); // 1 Shawwal
+  final dayArafah = _calculateIslamicHoliday(year, 12, 9); // 9 Dhul Hijjah
+  final eidAdha = _calculateIslamicHoliday(year, 12, 10); // 10 Dhul Hijjah
+
   return [
-    DateTime(year, 2, 22), // Founding Day
-    DateTime(year, 9, 23), // National Day
+    Holiday(name: 'عيد الفطر', date: eidFitr),
+    Holiday(name: 'يوم عرفة', date: dayArafah),
+    Holiday(name: 'عيد الأضحى', date: eidAdha),
+    Holiday(name: 'يوم التأسيس', date: DateTime(year, 2, 22)),
+    Holiday(name: 'اليوم الوطني', date: DateTime(year, 9, 23)),
+    Holiday(name: 'يوم العلم', date: DateTime(year, 3, 11)),
   ];
 }


### PR DESCRIPTION
## Summary
- define a `Holiday` model
- compute Islamic holiday dates per year
- store holiday names when saving settings
- display holiday names and confirm before deleting
- support new format when reading holidays

## Testing
- `git commit -m "Add recurring named holidays"`


------
https://chatgpt.com/codex/tasks/task_e_6847f1c95764832aa112dc986fb6ac4b