### PR TITLE
Fix holiday settings cast issue

### DIFF
--- a/lib/pages/admin/admin_holiday_settings_page.dart
+++ b/lib/pages/admin/admin_holiday_settings_page.dart
@@ -46,9 +46,14 @@ class _AdminHolidaySettingsPageState extends State<AdminHolidaySettingsPage> {
           .get();
       if (doc.exists) {
         final data = doc.data() as Map<String, dynamic>;
+        final weeklyData = data['weeklyHolidays'];
+        final weeklyList = (weeklyData is List ? weeklyData : [])
+            .map((e) => e is int ? e : int.tryParse(e.toString()))
+            .whereType<int>()
+            .toList();
         _selectedWeeklyHolidays
           ..clear()
-          ..addAll(List<int>.from(data['weeklyHolidays'] ?? []));
+          ..addAll(weeklyList);
         final loaded = (data['specialHolidays'] as List<dynamic>? ?? [])
             .map((d) {
               if (d is Map<String, dynamic>) {

--- a/lib/pages/admin/admin_settings_page.dart
+++ b/lib/pages/admin/admin_settings_page.dart
@@ -77,9 +77,14 @@ class _AdminSettingsPageState extends State<AdminSettingsPage> {
         _engineerHourlyRateController.text = (data['engineerHourlyRate'] ?? 50.0).toString();
         _workStartTimeController.text = data['workStartTime'] ?? '06:30';
         _workEndTimeController.text = data['workEndTime'] ?? '16:30';
+        final weeklyData = data['weeklyHolidays'];
+        final weeklyList = (weeklyData is List ? weeklyData : [])
+            .map((e) => e is int ? e : int.tryParse(e.toString()))
+            .whereType<int>()
+            .toList();
         _selectedWeeklyHolidays
           ..clear()
-          ..addAll(List<int>.from(data['weeklyHolidays'] ?? []));
+          ..addAll(weeklyList);
         final loaded = (data['specialHolidays'] as List<dynamic>? ?? [])
             .map((d) {
               if (d is Map<String, dynamic>) {


### PR DESCRIPTION
## Summary
- parse `weeklyHolidays` in admin pages more safely to avoid type cast errors

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f4489f58832a8a64371dbda60fe8