### PR TITLE
Fix holiday settings cast issue

### DIFF
--- a/lib/pages/admin/admin_holiday_settings_page.dart
+++ b/lib/pages/admin/admin_holiday_settings_page.dart
@@ -46,13 +46,20 @@ class _AdminHolidaySettingsPageState extends State<AdminHolidaySettingsPage> {
           .get();
       if (doc.exists) {
         final data = doc.data() as Map<String, dynamic>;
+        final weeklyData = data['weeklyHolidays'];
+        final weeklyList = (weeklyData is List ? weeklyData : [])
+            .map((e) => e is int ? e : int.tryParse(e.toString()))
+            .whereType<int>()
+            .toList();
         _selectedWeeklyHolidays
           ..clear()
-          ..addAll(List<int>.from(data['weeklyHolidays'] ?? []));
+          ..addAll(weeklyList);
         final loaded = (data['specialHolidays'] as List<dynamic>? ?? [])
             .map((d) {
               if (d is Map<String, dynamic>) {
                 return Holiday.fromMap(d);
+              } else if (d is Holiday) {
+                return d;
               } else if (d is String) {
                 final parsed = DateTime.tryParse(d);
                 return parsed != null ? Holiday(name: 'عطلة', date: parsed) : null;

--- a/lib/pages/admin/admin_settings_page.dart
+++ b/lib/pages/admin/admin_settings_page.dart
@@ -77,13 +77,20 @@ class _AdminSettingsPageState extends State<AdminSettingsPage> {
         _engineerHourlyRateController.text = (data['engineerHourlyRate'] ?? 50.0).toString();
         _workStartTimeController.text = data['workStartTime'] ?? '06:30';
         _workEndTimeController.text = data['workEndTime'] ?? '16:30';
+        final weeklyData = data['weeklyHolidays'];
+        final weeklyList = (weeklyData is List ? weeklyData : [])
+            .map((e) => e is int ? e : int.tryParse(e.toString()))
+            .whereType<int>()
+            .toList();
         _selectedWeeklyHolidays
           ..clear()
-          ..addAll(List<int>.from(data['weeklyHolidays'] ?? []));
+          ..addAll(weeklyList);
         final loaded = (data['specialHolidays'] as List<dynamic>? ?? [])
             .map((d) {
               if (d is Map<String, dynamic>) {
                 return Holiday.fromMap(d);
+              } else if (d is Holiday) {
+                return d;
               } else if (d is String) {
                 final parsed = DateTime.tryParse(d);
                 return parsed != null ? Holiday(name: 'عطلة', date: parsed) : null;

--- a/lib/pages/engineer/engineer_home.dart
+++ b/lib/pages/engineer/engineer_home.dart
@@ -12,6 +12,7 @@ import 'package:intl/intl.dart';
 import 'dart:ui' as ui;
 import '../../main.dart';
 import 'meeting_logs_page.dart';
+import '../../models/holiday.dart';
 
 
 class EngineerHome extends StatefulWidget {
@@ -428,11 +429,17 @@ class _EngineerHomeState extends State<EngineerHome> with TickerProviderStateMix
       final startDate = DateTime(now.year, now.month, now.day,
           int.parse(parts[0]), int.parse(parts[1]));
 
-      final weekly = List<int>.from(settings['weeklyHolidays'] ?? []);
+      final weeklyData = settings['weeklyHolidays'];
+      final weekly = (weeklyData is List ? weeklyData : [])
+          .map((e) => e is int ? e : int.tryParse(e.toString()))
+          .whereType<int>()
+          .toList();
       final special = (settings['specialHolidays'] as List<dynamic>? ?? [])
           .map((d) {
             if (d is Map<String, dynamic>) {
               return DateTime.tryParse(d['date'] ?? '');
+            } else if (d is Holiday) {
+              return d.date;
             } else if (d is String) {
               return DateTime.tryParse(d);
             }


### PR DESCRIPTION
## Summary
- parse `weeklyHolidays` in engineer home safely
- handle `Holiday` objects when loading settings

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f4489f58832a8a64371dbda60fe8