### PR TITLE
Fix compileSdkVersion configuration in Gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,8 +25,8 @@ subprojects {
 }
 
 // Ensure all plugins and modules compile with the same SDK level
-subprojects {
-    afterEvaluate { Project project ->
+gradle.projectsEvaluated {
+    subprojects { Project project ->
         if (project.hasProperty('android')) {
             project.android.compileSdkVersion = 34
         }


### PR DESCRIPTION
## Summary
- fix compileSdkVersion setup by using `gradle.projectsEvaluated`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68487fe8b738832aa3c715cb0eded2cf