### PR TITLE
Set compileSdk for subprojects

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,15 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+subprojects {
+    afterEvaluate { project ->
+        if (project.hasProperty('android')) {
+            project.android.compileSdkVersion = 35
+            project.android.defaultConfig.targetSdkVersion = 35
+        }
+    }
+}
+
 
 tasks.register("clean", Delete) {
     delete rootProject.buildDir


### PR DESCRIPTION
## Summary
- set compileSdk and targetSdk for all Android subprojects to resolve `lStar` build error

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488289bf8c832a9ca4cdb340a876b8