### PR TITLE
Fix Gradle afterEvaluate error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,12 +24,14 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
-subprojects {
-    afterEvaluate { project ->
-        if (project.hasProperty('android')) {
-            project.android.compileSdkVersion = 35
-            project.android.defaultConfig.targetSdkVersion = 35
-        }
+subprojects { project ->
+    project.plugins.withId('com.android.application') {
+        project.android.compileSdkVersion = 35
+        project.android.defaultConfig.targetSdkVersion = 35
+    }
+    project.plugins.withId('com.android.library') {
+        project.android.compileSdkVersion = 35
+        project.android.defaultConfig.targetSdkVersion = 35
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid calling `afterEvaluate` after evaluation
- use `plugins.withId` to set SDK versions for android subprojects

## Testing
- `flutter --version` *(fails: command not found)*
- `./gradlew --version` *(fails: No such file or directory)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494e21ade0832aa8fcd5be889b45c1