### PR TITLE
Fix fontFamily issue and add dark mode toggle

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:engineer_management_system/theme/app_constants.dart';
+import 'package:engineer_management_system/theme/theme_provider.dart';
 import 'firebase_options.dart';
 import 'package:engineer_management_system/pages/admin/admin_daily_schedule_page.dart'; // افترض هذا المسار
 import 'package:engineer_management_system/pages/auth/login_page.dart';
@@ -67,73 +68,85 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Engineer Management System',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: AppConstants.primaryColor),
-        useMaterial3: true,
-        fontFamily: 'Tajawal',
-        appBarTheme: const AppBarTheme(
-          color: AppConstants.primaryDark,
-          iconTheme: IconThemeData(color: Colors.white),
-          titleTextStyle: TextStyle(
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: themeProvider,
+      builder: (context, mode, _) {
+        return MaterialApp(
+          title: 'Engineer Management System',
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(seedColor: AppConstants.primaryColor),
+            useMaterial3: true,
             fontFamily: 'Tajawal',
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-            color: Colors.white,
+            appBarTheme: const AppBarTheme(
+              color: AppConstants.primaryDark,
+              iconTheme: IconThemeData(color: Colors.white),
+              titleTextStyle: TextStyle(
+                fontFamily: 'Tajawal',
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+            textTheme: const TextTheme(
+              bodyLarge: TextStyle(fontFamily: 'Tajawal', fontSize: 16.0),
+              bodyMedium: TextStyle(fontFamily: 'Tajawal', fontSize: 14.0),
+              displayLarge: TextStyle(fontFamily: 'Tajawal', fontSize: 32.0, fontWeight: FontWeight.bold),
+            ),
+            elevatedButtonTheme: ElevatedButtonThemeData(
+              style: ElevatedButton.styleFrom(
+                textStyle: const TextStyle(fontFamily: 'Tajawal', fontWeight: FontWeight.bold),
+              ),
+            ),
+            textButtonTheme: TextButtonThemeData(
+              style: TextButton.styleFrom(
+                textStyle: const TextStyle(fontFamily: 'Tajawal', fontWeight: FontWeight.w500),
+              ),
+            ),
           ),
-        ),
-        textTheme: const TextTheme(
-          bodyLarge: TextStyle(fontFamily: 'Tajawal', fontSize: 16.0),
-          bodyMedium: TextStyle(fontFamily: 'Tajawal', fontSize: 14.0),
-          displayLarge: TextStyle(fontFamily: 'Tajawal', fontSize: 32.0, fontWeight: FontWeight.bold),
-        ),
-        elevatedButtonTheme: ElevatedButtonThemeData(
-            style: ElevatedButton.styleFrom(
-                textStyle: const TextStyle(fontFamily: 'Tajawal', fontWeight: FontWeight.bold)
-            )
-        ),
-        textButtonTheme: TextButtonThemeData(
-            style: TextButton.styleFrom(
-                textStyle: const TextStyle(fontFamily: 'Tajawal', fontWeight: FontWeight.w500)
-            )
-        ),
-      ),
-      darkTheme: ThemeData.dark().copyWith(
-        colorScheme: ColorScheme.fromSeed(
-            seedColor: AppConstants.primaryColor,
-            brightness: Brightness.dark),
-        useMaterial3: true,
-        fontFamily: 'Tajawal',
-        appBarTheme: const AppBarTheme(
-          color: AppConstants.primaryDark,
-          iconTheme: IconThemeData(color: Colors.white),
-          titleTextStyle: TextStyle(
+          darkTheme: ThemeData(
+            brightness: Brightness.dark,
+            colorScheme: ColorScheme.fromSeed(
+              seedColor: AppConstants.primaryColor,
+              brightness: Brightness.dark,
+            ),
+            useMaterial3: true,
             fontFamily: 'Tajawal',
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-            color: Colors.white,
+            appBarTheme: const AppBarTheme(
+              color: AppConstants.primaryDark,
+              iconTheme: IconThemeData(color: Colors.white),
+              titleTextStyle: TextStyle(
+                fontFamily: 'Tajawal',
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+            textTheme: const TextTheme(
+              bodyLarge: TextStyle(fontFamily: 'Tajawal', fontSize: 16.0),
+              bodyMedium: TextStyle(fontFamily: 'Tajawal', fontSize: 14.0),
+              displayLarge: TextStyle(
+                fontFamily: 'Tajawal',
+                fontSize: 32.0,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            elevatedButtonTheme: ElevatedButtonThemeData(
+              style: ElevatedButton.styleFrom(
+                textStyle: const TextStyle(fontFamily: 'Tajawal', fontWeight: FontWeight.bold),
+              ),
+            ),
+            textButtonTheme: TextButtonThemeData(
+              style: TextButton.styleFrom(
+                textStyle: const TextStyle(fontFamily: 'Tajawal', fontWeight: FontWeight.w500),
+              ),
+            ),
           ),
-        ),
-        textTheme: const TextTheme(
-          bodyLarge: TextStyle(fontFamily: 'Tajawal', fontSize: 16.0),
-          bodyMedium: TextStyle(fontFamily: 'Tajawal', fontSize: 14.0),
-          displayLarge:
-              TextStyle(fontFamily: 'Tajawal', fontSize: 32.0, fontWeight: FontWeight.bold),
-        ),
-        elevatedButtonTheme: ElevatedButtonThemeData(
-            style: ElevatedButton.styleFrom(
-                textStyle: const TextStyle(fontFamily: 'Tajawal', fontWeight: FontWeight.bold))),
-        textButtonTheme: TextButtonThemeData(
-            style: TextButton.styleFrom(
-                textStyle: const TextStyle(fontFamily: 'Tajawal', fontWeight: FontWeight.w500))),
-      ),
-      themeMode: ThemeMode.system,
-      initialRoute: '/',
-      routes: {
-        '/': (context) => const AuthWrapper(),
-        '/login': (context) => const LoginPage(),
-        '/admin': (context) => const AdminDashboard(),
+          themeMode: mode,
+          initialRoute: '/',
+          routes: {
+            '/': (context) => const AuthWrapper(),
+            '/login': (context) => const LoginPage(),
+            '/admin': (context) => const AdminDashboard(),
         '/engineer': (context) => const EngineerHome(),
         '/client': (context) => const ClientHome(),
         '/admin/engineers': (context) => const AdminEngineersPage(),
@@ -183,6 +196,8 @@ class MyApp extends StatelessWidget {
       },
 
       debugShowCheckedModeBanner: false,
+        );
+      },
     );
   }
 }

--- a/lib/pages/admin/admin_dashboard.dart
+++ b/lib/pages/admin/admin_dashboard.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:engineer_management_system/theme/app_constants.dart';
+import 'package:engineer_management_system/theme/theme_provider.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
@@ -348,6 +349,22 @@ class _AdminDashboardState extends State<AdminDashboard> with TickerProviderStat
                 ),
               )
           ],
+        ),
+        IconButton(
+          icon: Icon(
+            themeProvider.value == ThemeMode.dark
+                ? Icons.light_mode
+                : Icons.dark_mode,
+            color: Colors.white,
+          ),
+          tooltip: themeProvider.value == ThemeMode.dark
+              ? 'الوضع الفاتح'
+              : 'الوضع المظلم',
+          onPressed: () {
+            setState(() {
+              themeProvider.toggle();
+            });
+          },
         ),
         // --- ADDITION END ---
         PopupMenuButton<String>(

--- a/lib/pages/client/client_home.dart
+++ b/lib/pages/client/client_home.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:engineer_management_system/theme/app_constants.dart';
+import 'package:engineer_management_system/theme/theme_provider.dart';
 import 'package:intl/intl.dart'; // For date formatting
 import 'dart:ui' as ui; // For TextDirection
 
@@ -567,6 +568,22 @@ class _ClientHomeState extends State<ClientHome> with TickerProviderStateMixin {
                 ),
               )
           ],
+        ),
+        IconButton(
+          icon: Icon(
+            themeProvider.value == ThemeMode.dark
+                ? Icons.light_mode
+                : Icons.dark_mode,
+            color: Colors.white,
+          ),
+          tooltip: themeProvider.value == ThemeMode.dark
+              ? 'الوضع الفاتح'
+              : 'الوضع المظلم',
+          onPressed: () {
+            setState(() {
+              themeProvider.toggle();
+            });
+          },
         ),
         PopupMenuButton<String>(
           icon: const Icon(Icons.more_vert, color: Colors.white),

--- a/lib/pages/engineer/engineer_home.dart
+++ b/lib/pages/engineer/engineer_home.dart
@@ -11,6 +11,7 @@ import 'package:signature/signature.dart';
 import 'package:intl/intl.dart';
 import 'dart:ui' as ui;
 import '../../main.dart';
+import 'package:engineer_management_system/theme/theme_provider.dart';
 import 'meeting_logs_page.dart';
 import '../../models/holiday.dart';
 
@@ -983,6 +984,22 @@ class _EngineerHomeState extends State<EngineerHome> with TickerProviderStateMix
                 ),
               )
           ],
+        ),
+        IconButton(
+          icon: Icon(
+            themeProvider.value == ThemeMode.dark
+                ? Icons.light_mode
+                : Icons.dark_mode,
+            color: Colors.white,
+          ),
+          tooltip: themeProvider.value == ThemeMode.dark
+              ? 'الوضع الفاتح'
+              : 'الوضع المظلم',
+          onPressed: () {
+            setState(() {
+              themeProvider.toggle();
+            });
+          },
         ),
         // --- ADDITION END ---
         PopupMenuButton<String>(

--- a/lib/theme/theme_provider.dart
+++ b/lib/theme/theme_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+/// A simple [ValueNotifier]-based theme controller.
+class ThemeProvider extends ValueNotifier<ThemeMode> {
+  ThemeProvider() : super(ThemeMode.system);
+
+  /// Toggle between dark and light themes.
+  void toggle() {
+    value = value == ThemeMode.dark ? ThemeMode.light : ThemeMode.dark;
+  }
+}
+
+/// Global instance used throughout the app.
+final ThemeProvider themeProvider = ThemeProvider();


### PR DESCRIPTION
## Summary
- fix `fontFamily` parameter usage and control theme with a `ThemeProvider`
- show a dark/light theme toggle icon next to notifications for all dashboards

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684959e81150832aaf6ab3a0ebf8b1cc