### PR TITLE
Switch to dark mode by default

### DIFF
--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -40,7 +40,7 @@ class ProjectDetailsPage extends StatefulWidget {
   State<ProjectDetailsPage> createState() => _ProjectDetailsPageState();
 }
 class AppConstants {
-  static const Color primaryColor = Color(0xFFE9C12C);
+  static const Color primaryColor = Color(0xFF21206C);
   static const Color primaryLight = Color(0xFFF3D660);
   static const Color successColor = Color(0xFF10B981);
   static const Color warningColor = Color(0xFFF59E0B);

--- a/lib/theme/app_constants.dart
+++ b/lib/theme/app_constants.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 class AppConstants {
   // Primary colors
-  static const Color primaryColor = Color(0xFFE9C12C);
+  static const Color primaryColor = Color(0xFF21206C);
   static const Color primaryLight = Color(0xFFF3D660);
   static const Color primaryDark = Color(0xFF21206C);
 

--- a/lib/theme/theme_provider.dart
+++ b/lib/theme/theme_provider.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 /// A simple [ValueNotifier]-based theme controller.
 class ThemeProvider extends ValueNotifier<ThemeMode> {
-  ThemeProvider() : super(ThemeMode.system);
+  ThemeProvider() : super(ThemeMode.dark);
 
   /// Toggle between dark and light themes.
   void toggle() {


### PR DESCRIPTION
## Summary
- set default theme mode to dark
- use dark navy `0xFF21206C` as the primary color everywhere

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495b6d315c832aa8b489f812456307