### PR TITLE
Allow optional credentials for employees and clients

### DIFF
--- a/lib/pages/admin/admin_engineers_page.dart
+++ b/lib/pages/admin/admin_engineers_page.dart
@@ -395,6 +395,7 @@ class _AdminEngineersPageState extends State<AdminEngineersPage> {
     TextInputType keyboardType = TextInputType.text,
     bool obscureText = false,
     String? Function(String?)? validator,
+    bool isRequired = true,
   }) {
     return TextFormField(
       controller: controller,
@@ -413,10 +414,10 @@ class _AdminEngineersPageState extends State<AdminEngineersPage> {
         ),
       ),
       validator: (value) {
-        if (value == null || value.isEmpty) {
+        if (isRequired && (value == null || value.isEmpty)) {
           return 'هذا الحقل مطلوب.';
         }
-        if (validator != null) {
+        if (validator != null && value != null && value.isNotEmpty) {
           return validator(value);
         }
         return null;

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -401,18 +401,11 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
           _projectDataSnapshot = projectDoc;
         });
 
-        final List<dynamic> assignedEngineersRaw = projectData?['assignedEngineers'] as List<dynamic>? ?? [];
-        final List<String> engineerIds = assignedEngineersRaw.map((e) => Map<String, dynamic>.from(e)['uid'].toString()).toList();
-        if (engineerIds.isNotEmpty) {
-          final empSnap = await FirebaseFirestore.instance
-              .collection('users')
-              .where('role', isEqualTo: 'employee')
-              .where('engineerId', whereIn: engineerIds.length > 10 ? engineerIds.sublist(0,10) : engineerIds)
-              .get();
-          if (mounted) setState(() => _projectEmployees = empSnap.docs);
-        } else {
-          if (mounted) setState(() => _projectEmployees = []);
-        }
+        final empSnap = await FirebaseFirestore.instance
+            .collection('users')
+            .where('role', isEqualTo: 'employee')
+            .get();
+        if (mounted) setState(() => _projectEmployees = empSnap.docs);
 
         final partSnap = await FirebaseFirestore.instance
             .collection('partRequests')

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -446,7 +446,6 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
     final employeesSnap = await FirebaseFirestore.instance
         .collection('users')
         .where('role', isEqualTo: 'employee')
-        .where('engineerId', isEqualTo: _currentEngineerUid)
         .get();
     final employees = employeesSnap.docs;
     if (employees.isEmpty) {


### PR DESCRIPTION
## Summary
- make employee email/password optional and drop engineer assignment
- allow clients to be added without credentials and store optional phone number
- show all employees when admins/engineers select workers
- adjust helper widgets to support optional fields

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acd7f8da0832ab60500010aca9486