### PR TITLE
Fix file picker mime type

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -12,6 +12,7 @@ import 'dart:io';
 import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
+import 'package:mime/mime.dart';
 import 'dart:typed_data';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:share_plus/share_plus.dart';
@@ -1343,6 +1344,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
     final picked = result.files.first;
     if (picked.path == null) return;
     final file = File(picked.path!);
+    final mimeType = lookupMimeType(picked.path!) ?? 'application/octet-stream';
     try {
       var request =
           http.MultipartRequest('POST', Uri.parse(AppConstants.uploadUrl));
@@ -1352,13 +1354,13 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
           'image',
           bytes,
           filename: picked.name,
-          contentType: MediaType.parse(picked.mimeType ?? 'application/octet-stream'),
+          contentType: MediaType.parse(mimeType),
         ));
       } else {
         request.files.add(await http.MultipartFile.fromPath(
           'image',
           file.path,
-          contentType: MediaType.parse(picked.mimeType ?? 'application/octet-stream'),
+          contentType: MediaType.parse(mimeType),
         ));
       }
 

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -11,6 +11,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'dart:io'; // For File
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
+import 'package:mime/mime.dart';
 import 'package:intl/intl.dart';
 import 'dart:convert';
 import 'dart:ui' as ui; // For TextDirection
@@ -679,6 +680,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
     final picked = result.files.first;
     if (picked.path == null) return;
     final file = File(picked.path!);
+    final mimeType = lookupMimeType(picked.path!) ?? 'application/octet-stream';
     try {
       var request =
           http.MultipartRequest('POST', Uri.parse(AppConstants.UPLOAD_URL));
@@ -688,13 +690,13 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
           'image',
           bytes,
           filename: picked.name,
-          contentType: MediaType.parse(picked.mimeType ?? 'application/octet-stream'),
+          contentType: MediaType.parse(mimeType),
         ));
       } else {
         request.files.add(await http.MultipartFile.fromPath(
           'image',
           file.path,
-          contentType: MediaType.parse(picked.mimeType ?? 'application/octet-stream'),
+          contentType: MediaType.parse(mimeType),
         ));
       }
 


### PR DESCRIPTION
## Summary
- compute MIME type from `PlatformFile.path` using `lookupMimeType`
- import the `mime` package where needed

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c519415c4832ab559ebac80d2d0be