### PR TITLE
Fix Material localization for DateRangePicker

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:engineer_management_system/pages/admin/admin_attendance_page.dar
 import 'package:engineer_management_system/pages/admin/admin_attendance_report_page.dart';
 import 'package:engineer_management_system/pages/notifications_page.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -99,6 +100,16 @@ class MyApp extends StatelessWidget {
               ),
             ),
           ),
+          localizationsDelegates: const [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [
+            Locale('en'),
+            Locale('ar'),
+          ],
+          locale: const Locale('ar'),
           initialRoute: '/',
           routes: {
             '/': (context) => const AuthWrapper(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
 
   flutter:
     sdk: flutter #
+  flutter_localizations:
+    sdk: flutter
   cupertino_icons: ^1.0.8 #
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add `flutter_localizations` package dependency
- wire up localization delegates and supported locales in `MyApp`
- import `flutter_localizations` in `main.dart`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5c8ce5cc832aaae89d5852a3018e