### PR TITLE
Allow attachments of any file type

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1346,7 +1346,10 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
   }
 
   Future<void> _showAddAttachmentDialog() async {
-    final result = await FilePicker.platform.pickFiles(allowMultiple: true);
+    final result = await FilePicker.platform.pickFiles(
+      allowMultiple: true,
+      type: FileType.any,
+    );
     if (result == null || result.files.isEmpty) return;
 
     final pickedFiles =

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -639,7 +639,10 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
 
   Future<void> _showAddAttachmentDialog() async {
     if (!mounted) return;
-    final result = await FilePicker.platform.pickFiles(allowMultiple: true);
+    final result = await FilePicker.platform.pickFiles(
+      allowMultiple: true,
+      type: FileType.any,
+    );
     if (result == null || result.files.isEmpty) return;
 
     final pickedFiles =


### PR DESCRIPTION
## Summary
- ensure the file picker accepts any file type when adding attachments

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c65893a6c832aa121fd522f5c66d0