### PR TITLE
Unify PDF styles and restrict report date options

### DIFF
--- a/lib/pages/admin/admin_evaluations_page.dart
+++ b/lib/pages/admin/admin_evaluations_page.dart
@@ -10,6 +10,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 import 'package:flutter/services.dart' show rootBundle;
+import '../../utils/pdf_styles.dart';
 import 'dart:io';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:engineer_management_system/html_stub.dart'
@@ -1307,10 +1308,13 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
 
     _showLoadingDialog(context, 'جاري إنشاء التقرير...');
 
+    final ByteData logoByteData = await rootBundle.load('assets/images/app_logo.png');
+    final Uint8List logoBytes = logoByteData.buffer.asUint8List();
+    final pw.MemoryImage appLogo = pw.MemoryImage(logoBytes);
+
     final pdf = pw.Document();
     final pw.TextStyle regular = pw.TextStyle(font: _arabicFont, fontSize: 12);
-    final pw.TextStyle bold = pw.TextStyle(
-        font: _arabicFont, fontWeight: pw.FontWeight.bold, fontSize: 14);
+    final pw.TextStyle bold = pw.TextStyle(font: _arabicFont, fontWeight: pw.FontWeight.bold, fontSize: 14);
 
     pdf.addPage(
       pw.MultiPage(
@@ -1318,12 +1322,16 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,
           theme: pw.ThemeData.withFont(base: _arabicFont),
-          margin: const pw.EdgeInsets.all(30),
+          margin: const pw.EdgeInsets.all(50),
+        ),
+        header: (context) => PdfStyles.buildHeader(
+          font: _arabicFont!,
+          logo: appLogo,
+          headerText: 'تقرير تقييم الموظف',
+          now: DateTime.now(),
         ),
         build: (context) =>
         [
-          pw.Header(
-              level: 0, child: pw.Text('تقرير تقييم الموظف', style: bold)),
           pw.Text('اسم الموظف: ${evaluation.engineerName}', style: regular),
           pw.Text('الفترة: ${evaluation.periodIdentifier}', style: regular),
           pw.Text(
@@ -1354,15 +1362,7 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
               text: 'عدد الإدخالات: ${evaluation.rawMetrics['totalEntries'] ??
                   '0'}', style: regular),
         ],
-        footer: (context) =>
-            pw.Container(
-              alignment: pw.Alignment.center,
-              margin: const pw.EdgeInsets.only(top: 1.0 * PdfPageFormat.cm),
-              child: pw.Text(
-                  'صفحة ${context.pageNumber} من ${context.pagesCount}',
-                  style: pw.TextStyle(
-                      font: _arabicFont, fontSize: 10, color: PdfColors.grey)),
-            ),
+        footer: (context) => PdfStyles.buildFooter(context, font: _arabicFont!),
       ),
     );
 

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -24,6 +24,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:image/image.dart' as img;
 import 'package:printing/printing.dart';
+import '../../utils/pdf_styles.dart';
 import 'package:engineer_management_system/html_stub.dart'
     if (dart.library.html) 'dart:html' as html;
 // import 'package:url_launcher/url_launcher.dart'; // Not used directly for notifications
@@ -1643,7 +1644,11 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
     final pw.TextStyle regularStyle = pw.TextStyle(font: _arabicFont, fontSize: 12);
     final pw.TextStyle headerStyle = pw.TextStyle(font: _arabicFont, fontWeight: pw.FontWeight.bold, fontSize: 16);
     final pw.TextStyle smallGrey = pw.TextStyle(font: _arabicFont, fontSize: 10, color: PdfColors.grey600);
-    final String headerText = useRange ? 'التقرير اليومي' : 'التقرير التراكمي';
+    final String headerText = useRange ? 'التقرير التراكمي' : 'التقرير اليومي';
+
+    final ByteData logoByteData = await rootBundle.load('assets/images/app_logo.png');
+    final Uint8List logoBytes = logoByteData.buffer.asUint8List();
+    final pw.MemoryImage appLogo = pw.MemoryImage(logoBytes);
 
     pdf.addPage(
       pw.MultiPage(
@@ -1651,13 +1656,16 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,
           theme: pw.ThemeData.withFont(base: _arabicFont),
-          margin: const pw.EdgeInsets.all(30),
+          margin: const pw.EdgeInsets.all(50),
+        ),
+        header: (context) => PdfStyles.buildHeader(
+          font: _arabicFont!,
+          logo: appLogo,
+          headerText: headerText,
+          now: now,
         ),
         build: (context) {
           final widgets = <pw.Widget>[];
-          widgets.add(pw.Header(level: 0, child: pw.Text(headerText, style: headerStyle)));
-          widgets.add(pw.Text('التاريخ: ${DateFormat('yyyy/MM/dd HH:mm', 'ar').format(now)}', style: regularStyle));
-          widgets.add(pw.SizedBox(height: 10));
           widgets.add(pw.Text('عدد الملاحظات المسجلة: ${dayEntries.length}', style: regularStyle));
           widgets.add(pw.Text('عدد الاختبارات المحدثة: ${dayTests.length}', style: regularStyle));
           widgets.add(pw.Text('عدد طلبات المواد: ${dayRequests.length}', style: regularStyle));
@@ -1754,11 +1762,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
 
           return widgets;
         },
-        footer: (context) => pw.Container(
-          alignment: pw.Alignment.center,
-          margin: const pw.EdgeInsets.only(top: 1.0 * PdfPageFormat.cm),
-          child: pw.Text('صفحة ${context.pageNumber} من ${context.pagesCount}', style: smallGrey),
-        ),
+        footer: (context) => PdfStyles.buildFooter(context, font: _arabicFont!),
       ),
     );
 

--- a/lib/utils/pdf_styles.dart
+++ b/lib/utils/pdf_styles.dart
@@ -1,0 +1,195 @@
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:intl/intl.dart';
+
+class PdfStyles {
+  static pw.Widget buildHeader({
+    required pw.Font font,
+    required pw.MemoryImage logo,
+    required String headerText,
+    required DateTime now,
+  }) {
+    final PdfColor primaryColor = PdfColor.fromHex('#1B4D3E');
+    final PdfColor lightGrey = PdfColor.fromHex('#F5F5F5');
+    final pw.TextStyle titleStyle = pw.TextStyle(
+      font: font,
+      fontWeight: pw.FontWeight.bold,
+      fontSize: 24,
+      color: primaryColor,
+    );
+    final pw.TextStyle regularStyle =
+        pw.TextStyle(font: font, fontSize: 12, color: PdfColors.black);
+
+    return pw.Container(
+      alignment: pw.Alignment.centerRight,
+      margin: const pw.EdgeInsets.only(bottom: 20),
+      decoration: pw.BoxDecoration(
+        color: lightGrey,
+        border: pw.Border(bottom: pw.BorderSide(color: primaryColor, width: 2)),
+      ),
+      padding: const pw.EdgeInsets.all(10),
+      child: pw.Row(
+        mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
+        children: [
+          pw.Column(
+            crossAxisAlignment: pw.CrossAxisAlignment.start,
+            children: [
+              pw.Text(headerText, style: titleStyle),
+              pw.SizedBox(height: 5),
+              pw.Text(
+                'تاريخ الإنشاء: ${DateFormat('dd-MM-yyyy HH:mm').format(now)}',
+                textDirection: pw.TextDirection.rtl,
+                style: regularStyle.copyWith(color: PdfColors.grey600),
+              ),
+            ],
+          ),
+          pw.Image(logo, width: 70, height: 70),
+        ],
+      ),
+    );
+  }
+
+  static pw.Widget buildFooter(pw.Context context, {required pw.Font font}) {
+    return pw.Container(
+      height: 80,
+      decoration: pw.BoxDecoration(
+        gradient: pw.LinearGradient(
+          colors: [PdfColor.fromHex('#1B4D3E'), PdfColor.fromHex('#2E8B57')],
+          begin: pw.Alignment.topLeft,
+          end: pw.Alignment.bottomRight,
+        ),
+      ),
+      child: pw.Padding(
+        padding: const pw.EdgeInsets.symmetric(horizontal: 30, vertical: 15),
+        child: pw.Column(
+          mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
+          children: [
+            pw.Row(
+              mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: pw.CrossAxisAlignment.center,
+              children: [
+                pw.Column(
+                  crossAxisAlignment: pw.CrossAxisAlignment.start,
+                  children: [
+                    pw.Text(
+                      'صفحة ${context.pageNumber} من ${context.pagesCount}',
+                      style: pw.TextStyle(
+                        font: font,
+                        color: PdfColors.white,
+                        fontSize: 10,
+                      ),
+                    ),
+                    pw.SizedBox(height: 2),
+                    pw.Text(
+                      'تم إنشاء هذا التقرير آلياً',
+                      style: pw.TextStyle(
+                        font: font,
+                        color: PdfColor.fromHex('#F5C842'),
+                        fontSize: 8,
+                      ),
+                    ),
+                  ],
+                ),
+                pw.Expanded(
+                  child: pw.Column(
+                    crossAxisAlignment: pw.CrossAxisAlignment.center,
+                    children: [
+                      pw.Row(
+                        mainAxisAlignment: pw.MainAxisAlignment.center,
+                        children: [
+                          pw.Text(
+                            'المملكة العربية السعودية - الأحساء - سجل تجاري رقم: ٢٢٠١٤٩٢٠٥٠',
+                            style: pw.TextStyle(
+                              font: font,
+                              color: PdfColors.white,
+                              fontSize: 9,
+                            ),
+                          ),
+                          pw.SizedBox(width: 10),
+                          pw.Container(
+                            width: 12,
+                            height: 12,
+                            decoration: pw.BoxDecoration(
+                              color: PdfColor.fromHex('#F5C842'),
+                              borderRadius: pw.BorderRadius.circular(6),
+                            ),
+                            child: pw.Center(
+                              child: pw.Text('📍', style: pw.TextStyle(fontSize: 8)),
+                            ),
+                          ),
+                        ],
+                      ),
+                      pw.SizedBox(height: 3),
+                      pw.Row(
+                        mainAxisAlignment: pw.MainAxisAlignment.center,
+                        children: [
+                          pw.Text(
+                            'الرقم الضريبي: ٣٠٠٤٧١٣٦٥٠٠٠٠٣',
+                            style: pw.TextStyle(
+                              font: font,
+                              color: PdfColor.fromHex('#F5C842'),
+                              fontSize: 9,
+                            ),
+                          ),
+                          pw.SizedBox(width: 20),
+                          pw.Text(
+                            '+966 54 538 8835',
+                            style: pw.TextStyle(
+                              font: font,
+                              color: PdfColors.white,
+                              fontSize: 9,
+                            ),
+                          ),
+                          pw.SizedBox(width: 10),
+                          pw.Container(
+                            width: 12,
+                            height: 12,
+                            decoration: pw.BoxDecoration(
+                              color: PdfColor.fromHex('#F5C842'),
+                              borderRadius: pw.BorderRadius.circular(6),
+                            ),
+                            child: pw.Center(
+                              child: pw.Text('📞', style: pw.TextStyle(fontSize: 8)),
+                            ),
+                          ),
+                        ],
+                      ),
+                      pw.SizedBox(height: 3),
+                      pw.Text(
+                        'bhbcont@outlook.sa',
+                        style: pw.TextStyle(
+                          font: font,
+                          color: PdfColor.fromHex('#F5C842'),
+                          fontSize: 9,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                pw.Container(
+                  width: 40,
+                  height: 40,
+                  decoration: pw.BoxDecoration(
+                    color: PdfColors.white,
+                    borderRadius: pw.BorderRadius.circular(5),
+                  ),
+                  child: pw.Center(
+                    child: pw.Text(
+                      'QR',
+                      style: pw.TextStyle(
+                        font: font,
+                        color: PdfColor.fromHex('#1B4D3E'),
+                        fontSize: 8,
+                        fontWeight: pw.FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add shared `PdfStyles` utilities for headers and footers
- apply the unified style to admin project reports and engineer PDFs
- use the style in admin evaluation PDFs
- limit report date selection to today or a custom range

## Testing
- `dart format` *(fails: command not found)*
- `flutter format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d32d70cf0832abc1a7e6bb60ba653