### PR TITLE
Support multiple items in material requests

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1015,8 +1015,18 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
           itemBuilder: (context, index) {
             final requestDoc = requests[index];
             final data = requestDoc.data() as Map<String, dynamic>;
-            final partName = data['partName'] ?? 'مادة غير مسماة';
-            final quantity = data['quantity']?.toString() ?? 'N/A';
+            final List<dynamic>? itemsData = data['items'];
+            String partName;
+            String quantity;
+            if (itemsData != null && itemsData.isNotEmpty) {
+              partName = itemsData
+                  .map((e) => '${e['name']} (${e['quantity']})')
+                  .join('، ');
+              quantity = '-';
+            } else {
+              partName = data['partName'] ?? 'مادة غير مسماة';
+              quantity = data['quantity']?.toString() ?? 'N/A';
+            }
             final engineerName = data['engineerName'] ?? 'مهندس غير معروف';
             final status = data['status'] ?? 'غير معروف';
             final requestedAt = (data['requestedAt'] as Timestamp?)?.toDate();
@@ -1732,14 +1742,16 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
             widgets.add(pw.Text('لا توجد طلبات مواد اليوم.', style: regularStyle));
           } else {
             for (var pr in dayRequests) {
-              final name = pr['partName'] ?? '';
-              final qty = pr['quantity']?.toString() ?? '1';
+              final List<dynamic>? items = pr['items'];
+              final itemSummary = (items != null && items.isNotEmpty)
+                  ? items.map((e) => '${e['name']} (${e['quantity']})').join('، ')
+                  : '${pr['partName'] ?? ''} (${pr['quantity'] ?? '1'})';
               final status = pr['status'] ?? '';
               final eng = pr['engineerName'] ?? '';
               final ts = (pr['requestedAt'] as Timestamp?)?.toDate();
               final dateStr = ts != null ? DateFormat('dd/MM/yy HH:mm', 'ar').format(ts) : '';
               widgets.add(pw.Bullet(
-                  text: '$name - الكمية: $qty - $status - $eng - $dateStr',
+                  text: '$itemSummary - $status - $eng - $dateStr',
                   textAlign: pw.TextAlign.right,
                   style: regularStyle));
             }

--- a/lib/pages/engineer/engineer_home.dart
+++ b/lib/pages/engineer/engineer_home.dart
@@ -850,8 +850,18 @@ class _EngineerHomeState extends State<EngineerHome> with TickerProviderStateMix
             itemBuilder: (context, index) {
               final requestDoc = requests[index];
               final data = requestDoc.data() as Map<String, dynamic>;
-              final partName = data['partName'] ?? 'مادة غير مسماة';
-              final quantity = data['quantity']?.toString() ?? 'N/A';
+              final List<dynamic>? itemsData = data['items'];
+              String partName;
+              String quantity;
+              if (itemsData != null && itemsData.isNotEmpty) {
+                partName = itemsData
+                    .map((e) => '${e['name']} (${e['quantity']})')
+                    .join('، ');
+                quantity = '-';
+              } else {
+                partName = data['partName'] ?? 'مادة غير مسماة';
+                quantity = data['quantity']?.toString() ?? 'N/A';
+              }
               final projectName = data['projectName'] ?? 'مشروع غير محدد';
               final status = data['status'] ?? 'غير معروف';
               final requestedAt = (data['requestedAt'] as Timestamp?)?.toDate();

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -1715,8 +1715,16 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
           ],
         ),
         ...requests.map((pr) {
-          final name = pr['partName'] ?? '';
-          final qty = pr['quantity']?.toString() ?? '1';
+          final List<dynamic>? items = pr['items'];
+          String name;
+          String qty;
+          if (items != null && items.isNotEmpty) {
+            name = items.map((e) => '${e['name']} (${e['quantity']})').join('، ');
+            qty = '-';
+          } else {
+            name = pr['partName'] ?? '';
+            qty = pr['quantity']?.toString() ?? '1';
+          }
           final status = pr['status'] ?? '';
           final eng = pr['engineerName'] ?? '';
           final ts = (pr['requestedAt'] as Timestamp?)?.toDate();
@@ -3425,12 +3433,14 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       contentWidgets.add(pw.SizedBox(height: 6));
       contentWidgets.add(pw.Text('القطع المطلوبة للمشروع:', style: boldStyle, textDirection: pw.TextDirection.rtl));
       for (var pr in partRequests) {
-        final String pName = pr['partName'] ?? '';
-        final String qty = pr['quantity']?.toString() ?? '1';
+        final List<dynamic>? items = pr['items'];
+        final String itemSummary = (items != null && items.isNotEmpty)
+            ? items.map((e) => '${e['name']} (${e['quantity']})').join('، ')
+            : '${pr['partName'] ?? ''} (${pr['quantity'] ?? '1'})';
         final String status = pr['status'] ?? '';
         final Timestamp? ts = pr['requestedAt'] as Timestamp?;
         final String dt = ts != null ? DateFormat('dd/MM/yy', 'ar').format(ts.toDate()) : '';
-        contentWidgets.add(pw.Bullet(text: '$pName - الكمية: $qty - $status - $dt', textAlign: pw.TextAlign.right, style: smallGreyStyle));
+        contentWidgets.add(pw.Bullet(text: '$itemSummary - $status - $dt', textAlign: pw.TextAlign.right, style: smallGreyStyle));
       }
     }
     contentWidgets.add(pw.Divider(height: 20, thickness: 1, color: PdfColors.grey400));


### PR DESCRIPTION
## Summary
- allow multiple items in material request form
- store list of items in each request document
- display multiple requested items for engineers and admins
- include item lists in generated PDFs

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d37e0b7e8832a9f78fe6c3646845d