### PR TITLE
Add notification highlighting

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,11 +122,27 @@ class MyApp extends StatelessWidget {
         '/admin/employees': (context) => const AdminEmployeesPage(),
         '/admin/projects': (context) => const AdminProjectsPage(),
         '/admin/projectDetails': (context) {
-          final projectId = ModalRoute.of(context)!.settings.arguments as String;
+          final args = ModalRoute.of(context)!.settings.arguments;
+          if (args is Map<String, dynamic>) {
+            return AdminProjectDetailsPage(
+              projectId: args['projectId'] as String,
+              highlightItemId: args['itemId'] as String?,
+              notificationType: args['notificationType'] as String?,
+            );
+          }
+          final projectId = args as String;
           return AdminProjectDetailsPage(projectId: projectId);
         },
         '/projectDetails': (context) {
-          final projectId = ModalRoute.of(context)!.settings.arguments as String;
+          final args = ModalRoute.of(context)!.settings.arguments;
+          if (args is Map<String, dynamic>) {
+            return ProjectDetailsPage(
+              projectId: args['projectId'] as String,
+              highlightItemId: args['itemId'] as String?,
+              notificationType: args['notificationType'] as String?,
+            );
+          }
+          final projectId = args as String;
           return ProjectDetailsPage(projectId: projectId);
         },
         '/admin/daily_schedule': (context) => const AdminDailySchedulePage(),

--- a/lib/pages/notifications_page.dart
+++ b/lib/pages/notifications_page.dart
@@ -144,7 +144,15 @@ class _NotificationsPageState extends State<NotificationsPage> {
 
       case 'project_assignment':
         if (_currentUserRole == 'engineer' && projectId != null && projectId.isNotEmpty) {
-          Navigator.pushNamed(context, '/projectDetails', arguments: projectId);
+          Navigator.pushNamed(
+            context,
+            '/projectDetails',
+            arguments: {
+              'projectId': projectId,
+              'itemId': itemId,
+              'notificationType': notificationType,
+            },
+          );
         } else if (_currentUserRole == 'client') {
           // Client does not get project assignment notifications directly
           // or they are handled by a general client home page, no deep link for client
@@ -164,8 +172,15 @@ class _NotificationsPageState extends State<NotificationsPage> {
       case 'project_entry_engineer': // المهندس أضاف إدخال
         if ((_currentUserRole == 'admin' || _currentUserRole == 'engineer') && projectId != null && projectId.isNotEmpty) {
           String detailRoute = _currentUserRole == 'admin' ? '/admin/projectDetails' : '/projectDetails';
-          Navigator.pushNamed(context, detailRoute, arguments: projectId);
-          // Future enhancement: pass itemId to scroll to the specific phase/test/entry.
+          Navigator.pushNamed(
+            context,
+            detailRoute,
+            arguments: {
+              'projectId': projectId,
+              'itemId': itemId,
+              'notificationType': notificationType,
+            },
+          );
         }
         break;
 

--- a/lib/theme/app_constants.dart
+++ b/lib/theme/app_constants.dart
@@ -22,6 +22,7 @@ class AppConstants {
   static const Color warningColor = Color(0xFFF59E0B);
   static const Color errorColor = Color(0xFFEF4444);
   static const Color infoColor = Color(0xFF3B82F6);
+  static const Color highlightColor = Color(0xFFFFF59D);
   static const Color deleteColor = errorColor;
 
   // Spacing and dimensions


### PR DESCRIPTION
## Summary
- add highlight color to constants
- allow project detail pages to accept highlight parameters
- scroll and highlight project phases/tests from notification click
- pass navigation info from notifications
- update routes for new args

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4928d580832a94a241694c377321