### PR TITLE
Include project info in PDF reports

### DIFF
--- a/lib/pages/admin/admin_evaluations_page.dart
+++ b/lib/pages/admin/admin_evaluations_page.dart
@@ -1341,6 +1341,8 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
           logo: appLogo,
           headerText: 'تقرير تقييم الموظف',
           now: DateTime.now(),
+          projectName: 'غير محدد',
+          clientName: 'غير محدد',
         ),
         build: (context) =>
         [

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1757,6 +1757,10 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         font: _arabicFont, fontSize: 10, color: PdfColors.grey600, fontFallback: commonFontFallback);
     final String headerText = useRange ? 'التقرير التراكمي' : 'التقرير اليومي';
 
+    final projectDataMap = _projectDataSnapshot?.data() as Map<String, dynamic>?;
+    final String projectName = projectDataMap?['name'] ?? 'مشروع غير مسمى';
+    final String clientName = projectDataMap?['clientName'] ?? 'غير معروف';
+
     final ByteData logoByteData = await rootBundle.load('assets/images/app_logo.png');
     final Uint8List logoBytes = logoByteData.buffer.asUint8List();
     final pw.MemoryImage appLogo = pw.MemoryImage(logoBytes);
@@ -1775,6 +1779,8 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
           logo: appLogo,
           headerText: headerText,
           now: now,
+          projectName: projectName,
+          clientName: clientName,
         ),
         build: (context) {
           final widgets = <pw.Widget>[];

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -1155,6 +1155,11 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       fontFallback: commonFontFallback, // Apply fallback
     );
 
+    final projectDataMap =
+        _projectDataSnapshot?.data() as Map<String, dynamic>?;
+    final String projectName = projectDataMap?['name'] ?? 'مشروع غير مسمى';
+    final String clientName = projectDataMap?['clientName'] ?? 'غير معروف';
+
     final bool isRange = start!.difference(end!).inDays != -1;
     final String headerText = isRange ? 'التقرير التراكمي' : 'التقرير اليومي';
 
@@ -1174,7 +1179,9 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
           regularStyle,
           primaryColor,
           lightGrey,
-          appLogo, // Pass the app logo to the header builder
+          appLogo,
+          projectName,
+          clientName,
         ),
         build: (context) {
           final widgets = <pw.Widget>[];
@@ -1281,7 +1288,9 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       pw.TextStyle regularStyle,
       PdfColor primaryColor,
       PdfColor lightGrey,
-      pw.MemoryImage appLogo, // <--- This parameter is crucial
+      pw.MemoryImage appLogo,
+      String projectName,
+      String clientName,
       ) {
     // Your existing _buildHeader logic, ensuring it uses 'appLogo' where the QR code was.
     return pw.Container(
@@ -1302,6 +1311,10 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
                 headerText,
                 style: titleStyle,
               ),
+              pw.SizedBox(height: 5),
+              pw.Text('المشروع: $projectName', style: regularStyle),
+              pw.SizedBox(height: 2),
+              pw.Text('العميل: $clientName', style: regularStyle),
               pw.SizedBox(height: 5),
               pw.Text(
                 'تاريخ الإنشاء: ${DateFormat('dd-MM-yyyy HH:mm').format(now)}',
@@ -3493,6 +3506,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         fontFallback: commonFontFallback);
 
     String projectName = (_projectDataSnapshot?.data() as Map<String, dynamic>)?['name'] ?? 'اسم المشروع غير محدد';
+    String clientName = (_projectDataSnapshot?.data() as Map<String, dynamic>)?['clientName'] ?? 'غير معروف';
     final List<dynamic> assignedEngs = (_projectDataSnapshot?.data() as Map<String, dynamic>?)?['assignedEngineers'] as List<dynamic>? ?? [];
     final String responsibleEngineers = assignedEngs.isNotEmpty
         ? assignedEngs.map((e) => (e as Map<String, dynamic>)['name'] ?? 'مهندس').join('، ')
@@ -3893,6 +3907,8 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
               logo: appLogo,
               headerText: headerText,
               now: DateTime.now(),
+              projectName: projectName,
+              clientName: clientName,
             ),
             build: (context) => contentWidgets,
             footer: (pw.Context context) => PdfStyles.buildFooter(context,

--- a/lib/utils/pdf_styles.dart
+++ b/lib/utils/pdf_styles.dart
@@ -8,6 +8,8 @@ class PdfStyles {
     required pw.MemoryImage logo,
     required String headerText,
     required DateTime now,
+    required String projectName,
+    required String clientName,
   }) {
     final PdfColor primaryColor = PdfColor.fromHex('#1B4D3E');
     final PdfColor lightGrey = PdfColor.fromHex('#F5F5F5');
@@ -35,6 +37,10 @@ class PdfStyles {
             crossAxisAlignment: pw.CrossAxisAlignment.start,
             children: [
               pw.Text(headerText, style: titleStyle),
+              pw.SizedBox(height: 5),
+              pw.Text('المشروع: $projectName', style: regularStyle),
+              pw.SizedBox(height: 2),
+              pw.Text('العميل: $clientName', style: regularStyle),
               pw.SizedBox(height: 5),
               pw.Text(
                 'تاريخ الإنشاء: ${DateFormat('dd-MM-yyyy HH:mm').format(now)}',


### PR DESCRIPTION
## Summary
- extend PDF header builder to take project and client names
- show project and client names when engineers and admins generate reports
- update evaluations page to match updated header API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea2a12c80832aa4368c34b1d8b07d