### PR TITLE
Add QR code link support in reports

### DIFF
--- a/lib/pages/admin/admin_attendance_report_page.dart
+++ b/lib/pages/admin/admin_attendance_report_page.dart
@@ -14,6 +14,7 @@ import 'package:pdf/widgets.dart' as pw;
 import 'package:engineer_management_system/html_stub.dart'
     if (dart.library.html) 'dart:html' as html;
 import '../../utils/pdf_styles.dart';
+import '../../utils/report_storage.dart';
 
 class AdminAttendanceReportPage extends StatefulWidget {
   const AdminAttendanceReportPage({super.key});
@@ -835,6 +836,9 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
     final pw.MemoryImage appLogo = pw.MemoryImage(logoData.buffer.asUint8List());
 
     final pdf = pw.Document();
+    final fileName = 'attendance_${DateFormat('yyyyMMdd').format(_selectedDate)}.pdf';
+    final token = generateReportToken();
+    final qrLink = buildReportDownloadUrl(fileName, token);
     final pw.TextStyle headerStyle = pw.TextStyle(
         font: _arabicFont,
         fontSize: 12,
@@ -937,14 +941,13 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
           ];
         },
         footer: (context) => PdfStyles.buildFooter(context,
-            font: _arabicFont!, fontFallback: commonFontFallback),
+            font: _arabicFont!, fontFallback: commonFontFallback, qrData: qrLink),
       ),
     );
 
     try {
       final pdfBytes = await pdf.save();
-      final fileName =
-          'attendance_${DateFormat('yyyyMMdd').format(_selectedDate)}.pdf';
+      await uploadReportPdf(pdfBytes, fileName, token);
 
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء التقرير بنجاح.', isError: false);

--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -15,6 +15,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'dart:typed_data';
 import 'package:image/image.dart' as img;
 import '../../utils/pdf_styles.dart';
+import '../../utils/report_storage.dart';
 import 'package:engineer_management_system/html_stub.dart'
     if (dart.library.html) 'dart:html' as html;
 import 'package:intl/intl.dart';
@@ -1128,6 +1129,10 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
     final fetchedImages = await _fetchImagesForUrls(imageUrls);
 
     final pdf = pw.Document();
+    final fileName =
+        'meeting_${DateFormat('yyyyMMdd_HHmmss').format(DateTime.now())}.pdf';
+    final token = generateReportToken();
+    final qrLink = buildReportDownloadUrl(fileName, token);
     final pw.TextStyle regularStyle = pw.TextStyle(
         font: _arabicFont, fontSize: 12, fontFallback: commonFontFallback);
     final pw.TextStyle headerStyle = pw.TextStyle(
@@ -1171,14 +1176,13 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
           return widgets;
         },
         footer: (context) => PdfStyles.buildFooter(context,
-            font: _arabicFont!, fontFallback: commonFontFallback),
+            font: _arabicFont!, fontFallback: commonFontFallback, qrData: qrLink),
       ),
     );
 
     try {
       final pdfBytes = await pdf.save();
-      final fileName =
-          'meeting_${DateFormat('yyyyMMdd_HHmmss').format(DateTime.now())}.pdf';
+      await uploadReportPdf(pdfBytes, fileName, token);
 
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء المحضر بنجاح.', isError: false);

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -25,6 +25,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:image/image.dart' as img;
 import 'package:printing/printing.dart';
 import '../../utils/pdf_styles.dart';
+import '../../utils/report_storage.dart';
 import 'package:engineer_management_system/html_stub.dart'
     if (dart.library.html) 'dart:html' as html;
 // import 'package:url_launcher/url_launcher.dart'; // Not used directly for notifications
@@ -1749,6 +1750,9 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
     final List<pw.Font> commonFontFallback = emojiFont != null ? [emojiFont!] : [];
 
     final pdf = pw.Document();
+    final fileName = 'daily_report_${DateFormat('yyyyMMdd_HHmmss').format(now)}.pdf';
+    final token = generateReportToken();
+    final qrLink = buildReportDownloadUrl(fileName, token);
     final pw.TextStyle regularStyle =
         pw.TextStyle(font: _arabicFont, fontSize: 12, fontFallback: commonFontFallback);
     final pw.TextStyle headerStyle = pw.TextStyle(
@@ -1883,13 +1887,13 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
           return widgets;
         },
         footer: (context) => PdfStyles.buildFooter(context,
-            font: _arabicFont!, fontFallback: commonFontFallback),
+            font: _arabicFont!, fontFallback: commonFontFallback, qrData: qrLink),
       ),
     );
 
     try {
       final pdfBytes = await pdf.save();
-      final fileName = 'daily_report_${DateFormat('yyyyMMdd_HHmmss').format(now)}.pdf';
+      await uploadReportPdf(pdfBytes, fileName, token);
 
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء التقرير بنجاح.', isError: false);

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -15,6 +15,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'dart:typed_data';
 import 'package:image/image.dart' as img;
 import '../../utils/pdf_styles.dart';
+import '../../utils/report_storage.dart';
 import 'package:engineer_management_system/html_stub.dart'
     if (dart.library.html) 'dart:html' as html;
 import 'dart:convert';
@@ -1173,6 +1174,10 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
     final fetchedImages = await _fetchImagesForUrls(imageUrls);
 
     final pdf = pw.Document();
+    final fileName =
+        'meeting_${DateFormat('yyyyMMdd_HHmmss').format(DateTime.now())}.pdf';
+    final token = generateReportToken();
+    final qrLink = buildReportDownloadUrl(fileName, token);
     final pw.TextStyle regularStyle = pw.TextStyle(
         font: _arabicFont, fontSize: 12, fontFallback: commonFontFallback);
 
@@ -1210,14 +1215,13 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
           return widgets;
         },
         footer: (context) => PdfStyles.buildFooter(context,
-            font: _arabicFont!, fontFallback: commonFontFallback),
+            font: _arabicFont!, fontFallback: commonFontFallback, qrData: qrLink),
       ),
     );
 
     try {
       final pdfBytes = await pdf.save();
-      final fileName =
-          'meeting_${DateFormat('yyyyMMdd_HHmmss').format(DateTime.now())}.pdf';
+      await uploadReportPdf(pdfBytes, fileName, token);
 
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء المحضر بنجاح.', isError: false);

--- a/lib/utils/pdf_styles.dart
+++ b/lib/utils/pdf_styles.dart
@@ -1,5 +1,6 @@
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
+import 'package:barcode/barcode.dart';
 import 'package:intl/intl.dart';
 
 class PdfStyles {
@@ -56,7 +57,9 @@ class PdfStyles {
   }
 
   static pw.Widget buildFooter(pw.Context context,
-      {required pw.Font font, List<pw.Font> fontFallback = const []}) {
+      {required pw.Font font,
+      List<pw.Font> fontFallback = const [],
+      String? qrData}) {
     return pw.Container(
       height: 80,
       decoration: pw.BoxDecoration(
@@ -193,16 +196,23 @@ class PdfStyles {
                     borderRadius: pw.BorderRadius.circular(5),
                   ),
                   child: pw.Center(
-                    child: pw.Text(
-                      'QR',
-                      style: pw.TextStyle(
-                        font: font,
-                        color: PdfColor.fromHex('#1B4D3E'),
-                        fontSize: 8,
-                        fontWeight: pw.FontWeight.bold,
-                        fontFallback: fontFallback,
-                      ),
-                    ),
+                    child: qrData != null
+                        ? pw.BarcodeWidget(
+                            barcode: pw.Barcode.qrCode(),
+                            data: qrData!,
+                            width: 40,
+                            height: 40,
+                          )
+                        : pw.Text(
+                            'QR',
+                            style: pw.TextStyle(
+                              font: font,
+                              color: PdfColor.fromHex('#1B4D3E'),
+                              fontSize: 8,
+                              fontWeight: pw.FontWeight.bold,
+                              fontFallback: fontFallback,
+                            ),
+                          ),
                   ),
                 ),
               ],

--- a/lib/utils/report_storage.dart
+++ b/lib/utils/report_storage.dart
@@ -1,0 +1,27 @@
+import 'dart:typed_data';
+
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:uuid/uuid.dart';
+
+/// Generates a unique token for use with Firebase Storage download URLs.
+String generateReportToken() => const Uuid().v4();
+
+/// Builds the public download URL for a PDF report using the given [fileName]
+/// and [token].
+String buildReportDownloadUrl(String fileName, String token) {
+  final bucket = FirebaseStorage.instance.bucket;
+  final encodedPath = Uri.encodeComponent('reports/\$fileName');
+  return 'https://firebasestorage.googleapis.com/v0/b/\$bucket/o/\$encodedPath?alt=media&token=\$token';
+}
+
+/// Uploads [bytes] to Firebase Storage under `reports/[fileName]` with the
+/// provided [token] so the download URL is stable.
+Future<void> uploadReportPdf(Uint8List bytes, String fileName, String token) async {
+  final ref = FirebaseStorage.instance.ref().child('reports/\$fileName');
+  await ref.putData(
+    bytes,
+    SettableMetadata(customMetadata: {
+      'firebaseStorageDownloadTokens': token,
+    }),
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   file_picker: ^6.1.1 #
   fl_chart: ^0.68.0 #
   table_calendar: ^3.1.2 #
+  uuid: ^3.0.7
 
 
   flutter:


### PR DESCRIPTION
## Summary
- add helper functions to upload PDF reports and generate download links
- generate QR codes in PDF footer for each report
- upload generated PDFs to Firebase Storage with stable tokens
- update all report pages to include QR links in footers
- add `uuid` dependency

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eabcb286c832ab9dd628786a2387b