### PR TITLE
Add PDF preview screen and WhatsApp sharing

### DIFF
--- a/docs/report_suggestions.md
+++ b/docs/report_suggestions.md
@@ -1,0 +1,38 @@
+# Professional PDF Report Suggestions
+
+This document outlines recommendations for improving the generated project and meeting reports.
+
+## Cover Page
+- Include company logo, project title, client name, engineer name and creation date.
+- Provide report type (daily report, phase completion, meeting log, etc.).
+
+## Table of Contents
+- For multi‑page reports, generate a table listing section titles with page numbers.
+- Use `pdf` package widgets to compute page indices after document generation if needed.
+
+## Standard Sections
+- **Executive Summary** – short overview of progress or meeting outcomes.
+- **Updates/Notes** – chronological list of entries with timestamps and responsible engineers.
+- **Tests/Inspections** – summary table of performed tests with status and results.
+- **Requests/Materials** – table showing requested items, quantities and statuses.
+
+## Data Visualisation
+- Use charts (e.g. bar charts or progress indicators) for phase completion percentage and resource usage. Generate charts using `fl_chart` in Flutter and convert them to images for embedding in the PDF.
+
+## Additional Data Points
+- Pull timestamps for each update from Firestore and display them beside notes.
+- Show engineer responsible for each task or phase.
+- For admins, include material quantity comparisons and basic budget information if available.
+
+## Visual Style
+- Apply consistent fonts and colours from `AppConstants`.
+- Keep margins generous and use whitespace for clarity.
+- Add page footer with company contact details and disclaimers (see `PdfStyles.buildFooter`).
+
+## Signatures and Approval
+- Include captured digital signatures using the `signature` package.
+- Present an approval stamp or image after finalised reports.
+
+## QR Codes
+- Continue using QR codes linking to the online version of the report via `buildReportDownloadUrl`.
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'dart:typed_data';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:engineer_management_system/theme/app_constants.dart';
 import 'firebase_options.dart';
@@ -29,6 +30,7 @@ import 'package:engineer_management_system/pages/engineer/request_material_page.
 import 'package:engineer_management_system/pages/engineer/meeting_logs_page.dart';
 import 'package:engineer_management_system/pages/admin/admin_meeting_logs_page.dart';
 import 'package:engineer_management_system/pages/common/change_password_page.dart';
+import 'package:engineer_management_system/pages/common/pdf_preview_screen.dart';
 
 // --- ADDITION START ---
 import 'package:engineer_management_system/pages/admin/admin_evaluations_page.dart'; // استيراد صفحة التقييم الجديدة
@@ -172,6 +174,17 @@ class MyApp extends StatelessWidget {
             return MeetingLogsPage(engineerId: engineerId);
           }
           return const LoginPage();
+        },
+        '/pdf_preview': (context) {
+          final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>?;
+          if (args != null && args['bytes'] != null && args['fileName'] != null && args['text'] != null) {
+            return PdfPreviewScreen(
+              pdfBytes: args['bytes'] as Uint8List,
+              fileName: args['fileName'] as String,
+              shareText: args['text'] as String,
+            );
+          }
+          return const Scaffold(body: Center(child: Text('لا يمكن عرض الملف')));
         },
         // --- ADDITION START ---
         '/admin/evaluations': (context) => const AdminEvaluationsPage(), // مسار جديد لصفحة التقييم

--- a/lib/pages/common/pdf_preview_screen.dart
+++ b/lib/pages/common/pdf_preview_screen.dart
@@ -1,0 +1,58 @@
+import 'dart:typed_data';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:printing/printing.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../theme/app_constants.dart';
+
+class PdfPreviewScreen extends StatelessWidget {
+  final Uint8List pdfBytes;
+  final String fileName;
+  final String shareText;
+
+  const PdfPreviewScreen({
+    Key? key,
+    required this.pdfBytes,
+    required this.fileName,
+    required this.shareText,
+  }) : super(key: key);
+
+  Future<void> _sharePdf(BuildContext context) async {
+    if (kIsWeb) {
+      await Share.shareXFiles([XFile.fromData(pdfBytes, name: fileName, mimeType: 'application/pdf')], text: shareText);
+    } else {
+      final dir = await getTemporaryDirectory();
+      final path = '${dir.path}/$fileName';
+      final file = File(path);
+      await file.writeAsBytes(pdfBytes, flush: true);
+      await Share.shareXFiles([XFile(path)], text: shareText);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('معاينة PDF', style: TextStyle(color: Colors.white)),
+        backgroundColor: AppConstants.primaryColor,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.whatsapp, color: Colors.white),
+            tooltip: 'مشاركة عبر واتساب',
+            onPressed: () => _sharePdf(context),
+          ),
+        ],
+      ),
+      body: PdfPreview(
+        build: (format) async => pdfBytes,
+        allowPrinting: false,
+        allowSharing: false,
+        canChangePageFormat: false,
+      ),
+    );
+  }
+}

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1137,6 +1137,14 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
     }
   }
 
+  void _openPdfPreview(Uint8List pdfBytes, String fileName, String text) {
+    Navigator.of(context).pushNamed('/pdf_preview', arguments: {
+      'bytes': pdfBytes,
+      'fileName': fileName,
+      'text': text,
+    });
+  }
+
   Future<void> _generateMeetingPdf(Map<String, dynamic> data) async {
     final DateTime meetingDate =
         (data['date'] as Timestamp?)?.toDate() ?? DateTime.now();
@@ -1227,8 +1235,11 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء المحضر بنجاح.', isError: false);
 
-      await _saveOrSharePdf(pdfBytes, fileName, 'محضر اجتماع',
-          'يرجى الاطلاع على المحضر المرفق.');
+      _openPdfPreview(
+        pdfBytes,
+        fileName,
+        'يرجى الاطلاع على المحضر المرفق.',
+      );
     } catch (e) {
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'فشل إنشاء أو مشاركة المحضر: $e',

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -1273,10 +1273,9 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       await uploadReportPdf(pdfBytes, fileName, token);
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء التقرير بنجاح.', isError: false);
-      await _saveOrSharePdf(
+      _openPdfPreview(
         pdfBytes,
         fileName,
-        headerText,
         'يرجى الإطلاع على $headerText للمشروع.',
       );
     } catch (e) {
@@ -3939,10 +3938,9 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, "تم إنشاء التقرير بنجاح.", isError: false);
 
-      await _saveOrSharePdf(
+      _openPdfPreview(
         pdfBytes,
         fileName,
-        'تقرير مشروع: $projectName - $name',
         'الرجاء الإطلاع على تقرير ${isTestSection ? "الاختبار" : "المرحلة"}: $name لمشروع $projectName.'
       );
 
@@ -3973,6 +3971,14 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         text: text,
       );
     }
+  }
+
+  void _openPdfPreview(Uint8List pdfBytes, String fileName, String text) {
+    Navigator.of(context).pushNamed('/pdf_preview', arguments: {
+      'bytes': pdfBytes,
+      'fileName': fileName,
+      'text': text,
+    });
   }
 
 


### PR DESCRIPTION
## Summary
- create a PDF preview screen with WhatsApp sharing button
- expose new `/pdf_preview` route
- show preview instead of direct share for project and meeting PDFs
- document layout suggestions for professional reports

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685168f5eac0832a9a5b1fec702b75b7