### PR TITLE
Restrict engineer report generation and update headers

### DIFF
--- a/lib/pages/admin/admin_attendance_report_page.dart
+++ b/lib/pages/admin/admin_attendance_report_page.dart
@@ -860,7 +860,7 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
         header: (context) => PdfStyles.buildHeader(
           font: _arabicFont!,
           logo: appLogo,
-          headerText: 'تقرير الحضور اليومي',
+          headerText: AppConstants.attendanceReportHeader,
           now: _selectedDate,
           projectName: 'غير محدد',
           clientName: 'غير محدد',
@@ -954,7 +954,10 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
       _showFeedbackSnackBar(context, 'تم إنشاء التقرير بنجاح.', isError: false);
 
       await _saveOrSharePdf(
-          pdfBytes, fileName, 'تقرير الحضور', 'يرجى الاطلاع على التقرير المرفق.');
+          pdfBytes,
+          fileName,
+          AppConstants.attendanceReportHeader,
+          'يرجى الاطلاع على التقرير المرفق.');
     } catch (e) {
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(
@@ -972,7 +975,7 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
         appBar: AppBar(
           centerTitle: true,
           title: const Text(
-            'تقرير الحضور اليومي',
+            AppConstants.attendanceReportHeader,
             style: TextStyle(
               fontWeight: FontWeight.bold,
               fontSize: 22,

--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1153,7 +1153,7 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
         header: (context) => PdfStyles.buildHeader(
           font: _arabicFont!,
           logo: appLogo,
-          headerText: 'محضر اجتماع',
+          headerText: AppConstants.meetingReportHeader,
           now: meetingDate,
           projectName: data['title'] ?? 'اجتماع',
           clientName:
@@ -1187,7 +1187,10 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء المحضر بنجاح.', isError: false);
 
-      await _saveOrSharePdf(pdfBytes, fileName, 'محضر اجتماع',
+      await _saveOrSharePdf(
+          pdfBytes,
+          fileName,
+          AppConstants.meetingReportHeader,
           'يرجى الاطلاع على المحضر المرفق.');
     } catch (e) {
       _hideLoadingDialog(context);

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1202,7 +1202,7 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
         header: (context) => PdfStyles.buildHeader(
           font: _arabicFont!,
           logo: appLogo,
-          headerText: 'محضر اجتماع',
+          headerText: AppConstants.meetingReportHeader,
           now: meetingDate,
           projectName: data['title'] ?? 'اجتماع',
           clientName: data['type'] == 'client' ? 'عميل' : 'موظفين',

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -2101,6 +2101,15 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
     );
   }
 
+  bool _isCurrentEngineerResponsible() {
+    if (_projectDataSnapshot == null || _currentEngineerUid == null) return false;
+    final data = _projectDataSnapshot!.data() as Map<String, dynamic>?;
+    if (data == null) return false;
+    final List<dynamic> uidsDynamic = data['engineerUids'] as List<dynamic>? ?? [];
+    final List<String> uids = uidsDynamic.map((e) => e.toString()).toList();
+    return uids.contains(_currentEngineerUid);
+  }
+
   // --- Helper for loading dialog ---
   void _showLoadingDialog(BuildContext context, String message) {
     if (!mounted) return;
@@ -2297,7 +2306,8 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
               }
 
               bool canEngineerEditThisPhase = !isMainPhaseCompletedByAnyEngineer;
-              bool canGeneratePdfForMainPhase = isMainPhaseCompletedByAnyEngineer && mainPhaseCompletedByUid == _currentEngineerUid;
+              bool canGeneratePdfForMainPhase =
+                  isMainPhaseCompletedByAnyEngineer && _isCurrentEngineerResponsible();
 
               Widget? trailingWidget;
               if (canEngineerEditThisPhase) {
@@ -2471,7 +2481,8 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
                       testCompletedByUid = statusData['lastUpdatedByUid'] as String?;
                     }
                     bool canEngineerEditThisTest = !isTestCompleted;
-                    bool canGeneratePdfForTest = isTestCompleted && testCompletedByUid == _currentEngineerUid;
+                    bool canGeneratePdfForTest =
+                        isTestCompleted && _isCurrentEngineerResponsible();
 
                     Widget? trailingWidget;
                     if (canEngineerEditThisTest) {

--- a/lib/theme/app_constants.dart
+++ b/lib/theme/app_constants.dart
@@ -49,4 +49,8 @@ class AppConstants {
   // File upload
   static const String uploadUrl = '$baseUrl/images_upload/upload_image.php';
   static const String baseUrl = 'https://bhbgroup.me';
+
+  // PDF header titles
+  static const String meetingReportHeader = 'تقرير الاجتماع';
+  static const String attendanceReportHeader = 'سجل الحضور اليومي';
 }


### PR DESCRIPTION
## Summary
- add constants for meeting and attendance report headers
- allow any assigned engineer to generate project PDFs
- use new header constants in meeting and attendance reports

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516cef3d88832a83e4daec0385519d