### PR TITLE
Add full project report option and WhatsApp sharing

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1554,6 +1554,13 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
               child: const Text('تقرير اليوم'),
             ),
             SimpleDialogOption(
+              onPressed: () {
+                Navigator.pop(ctx);
+                _generateDailyReportPdf();
+              },
+              child: const Text('تقرير شامل'),
+            ),
+            SimpleDialogOption(
               onPressed: () async {
                 Navigator.pop(ctx);
                 final DateTimeRange? range = await showDateRangePicker(
@@ -1593,9 +1600,12 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
 
   Future<void> _generateDailyReportPdf({DateTime? start, DateTime? end}) async {
     DateTime now = DateTime.now();
-    final bool useRange = start != null && end != null;
-    start ??= DateTime(now.year, now.month, now.day);
-    end ??= start.add(const Duration(days: 1));
+    final bool isFullReport = start == null && end == null;
+    bool useRange = !isFullReport;
+    if (useRange) {
+      start ??= DateTime(now.year, now.month, now.day);
+      end ??= start.add(const Duration(days: 1));
+    }
 
     final List<Map<String, dynamic>> dayEntries = [];
     final List<Map<String, dynamic>> dayTests = [];
@@ -1759,7 +1769,11 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         font: _arabicFont, fontWeight: pw.FontWeight.bold, fontSize: 16, fontFallback: commonFontFallback);
     final pw.TextStyle smallGrey = pw.TextStyle(
         font: _arabicFont, fontSize: 10, color: PdfColors.grey600, fontFallback: commonFontFallback);
-    final String headerText = useRange ? 'التقرير التراكمي' : 'التقرير اليومي';
+    final String headerText = isFullReport
+        ? 'التقرير الشامل'
+        : useRange
+            ? 'التقرير التراكمي'
+            : 'التقرير اليومي';
 
     final projectDataMap = _projectDataSnapshot?.data() as Map<String, dynamic>?;
     final String projectName = projectDataMap?['name'] ?? 'مشروع غير مسمى';

--- a/lib/pages/common/pdf_preview_screen.dart
+++ b/lib/pages/common/pdf_preview_screen.dart
@@ -40,10 +40,11 @@ class PdfPreviewScreen extends StatelessWidget {
         title: const Text('معاينة PDF', style: TextStyle(color: Colors.white)),
         backgroundColor: AppConstants.primaryColor,
         actions: [
-          IconButton(
-            icon: const Icon(Icons.whatsapp, color: Colors.white),
-            tooltip: 'مشاركة عبر واتساب',
+          TextButton.icon(
             onPressed: () => _sharePdf(context),
+            icon: const Icon(Icons.whatsapp, color: Colors.white),
+            label: const Text('مشاركة واتساب', style: TextStyle(color: Colors.white)),
+            style: TextButton.styleFrom(foregroundColor: Colors.white),
           ),
         ],
       ),

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -898,6 +898,13 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
               child: const Text('تقرير اليوم'),
             ),
             SimpleDialogOption(
+              onPressed: () {
+                Navigator.pop(ctx);
+                _generateDailyReportPdf();
+              },
+              child: const Text('تقرير شامل'),
+            ),
+            SimpleDialogOption(
               onPressed: () async {
                 Navigator.pop(ctx);
                 final DateTimeRange? range = await showDateRangePicker(
@@ -949,8 +956,12 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
 
   Future<void> _generateDailyReportPdf({DateTime? start, DateTime? end}) async {
     DateTime now = DateTime.now();
-    start ??= DateTime(now.year, now.month, now.day);
-    end ??= start.add(const Duration(days: 1)); // Default to end of today if not a range
+    final bool isFullReport = start == null && end == null;
+    bool useRange = !isFullReport;
+    if (useRange) {
+      start ??= DateTime(now.year, now.month, now.day);
+      end ??= start.add(const Duration(days: 1)); // Default to end of today if not a range
+    }
 
     _showLoadingDialog(context, 'جاري إنشاء التقرير...');
 
@@ -1166,8 +1177,12 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
     final String projectName = projectDataMap?['name'] ?? 'مشروع غير مسمى';
     final String clientName = projectDataMap?['clientName'] ?? 'غير معروف';
 
-    final bool isRange = start!.difference(end!).inDays != -1;
-    final String headerText = isRange ? 'التقرير التراكمي' : 'التقرير اليومي';
+    final bool isRange = useRange && end!.difference(start!).inDays > 1;
+    final String headerText = isFullReport
+        ? 'التقرير الشامل'
+        : isRange
+            ? 'التقرير التراكمي'
+            : 'التقرير اليومي';
 
     pdf.addPage(
       pw.MultiPage(


### PR DESCRIPTION
## Summary
- add "تقرير شامل" option in report type dialog for admins and engineers
- allow PDF generation without date filters
- show "التقرير الشامل" header for full reports
- update PDF preview to include a WhatsApp share text button

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685177842bf0832a94da103b90de3fe1