### PR TITLE
Improve PDF generation speed

### DIFF
--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -15,6 +15,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'dart:typed_data';
 import 'package:image/image.dart' as img;
 import '../../utils/pdf_styles.dart';
+import '../../utils/pdf_image_cache.dart';
 import '../../utils/report_storage.dart';
 import 'package:engineer_management_system/html_stub.dart'
     if (dart.library.html) 'dart:html' as html;
@@ -1057,13 +1058,22 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
     final Map<String, pw.MemoryImage> fetched = {};
     await Future.wait(urls.map((url) async {
       if (fetched.containsKey(url)) return;
+
+      final cached = PdfImageCache.get(url);
+      if (cached != null) {
+        fetched[url] = cached;
+        return;
+      }
+
       try {
         final response = await http.get(Uri.parse(url));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final decoded = img.decodeImage(response.bodyBytes);
           if (decoded != null) {
-            fetched[url] = pw.MemoryImage(response.bodyBytes);
+            final memImg = pw.MemoryImage(response.bodyBytes);
+            fetched[url] = memImg;
+            PdfImageCache.put(url, memImg);
           }
         }
       } catch (e) {

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -25,6 +25,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:image/image.dart' as img;
 import 'package:printing/printing.dart';
 import '../../utils/pdf_styles.dart';
+import '../../utils/pdf_image_cache.dart';
 import '../../utils/report_storage.dart';
 import 'package:engineer_management_system/html_stub.dart'
     if (dart.library.html) 'dart:html' as html;
@@ -1980,13 +1981,22 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
     final Map<String, pw.MemoryImage> fetched = {};
     await Future.wait(urls.map((url) async {
       if (fetched.containsKey(url)) return;
+
+      final cached = PdfImageCache.get(url);
+      if (cached != null) {
+        fetched[url] = cached;
+        return;
+      }
+
       try {
         final response = await http.get(Uri.parse(url));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final decoded = img.decodeImage(response.bodyBytes);
           if (decoded != null) {
-            fetched[url] = pw.MemoryImage(response.bodyBytes);
+            final memImg = pw.MemoryImage(response.bodyBytes);
+            fetched[url] = memImg;
+            PdfImageCache.put(url, memImg);
           }
         }
       } catch (e) {

--- a/lib/utils/pdf_image_cache.dart
+++ b/lib/utils/pdf_image_cache.dart
@@ -1,0 +1,12 @@
+import "package:pdf/widgets.dart" as pw;
+class PdfImageCache {
+  PdfImageCache._();
+
+  static final Map<String, pw.MemoryImage> _cache = {};
+
+  static pw.MemoryImage? get(String url) => _cache[url];
+
+  static void put(String url, pw.MemoryImage image) {
+    _cache[url] = image;
+  }
+}


### PR DESCRIPTION
## Summary
- add `PdfImageCache` utility
- cache downloaded images when generating PDFs

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685179e1c5e4832a9e12b281113ee9d9