### PR TITLE
Handle network timeouts when generating reports

### DIFF
--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:engineer_management_system/theme/app_constants.dart';
+import 'dart:async';
 import 'package:image_picker/image_picker.dart';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
@@ -1066,7 +1067,8 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
       }
 
       try {
-        final response = await http.get(Uri.parse(url));
+        final response =
+            await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final decoded = img.decodeImage(response.bodyBytes);
@@ -1076,6 +1078,8 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
             PdfImageCache.put(url, memImg);
           }
         }
+      } on TimeoutException catch (_) {
+        print('Timeout fetching image from URL $url');
       } catch (e) {
         print('Error fetching image from URL $url: $e');
       }

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -7,6 +7,7 @@ import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:engineer_management_system/theme/app_constants.dart';
+import 'dart:async';
 import 'package:image_picker/image_picker.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -1989,7 +1990,8 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
       }
 
       try {
-        final response = await http.get(Uri.parse(url));
+        final response =
+            await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final decoded = img.decodeImage(response.bodyBytes);
@@ -1999,6 +2001,8 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
             PdfImageCache.put(url, memImg);
           }
         }
+      } on TimeoutException catch (_) {
+        print('Timeout fetching image from URL $url');
       } catch (e) {
         print('Error fetching image from URL $url: $e');
       }

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'dart:ui' as ui;
 import 'package:engineer_management_system/theme/app_constants.dart';
+import 'dart:async';
 import 'package:intl/intl.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:http/http.dart' as http;
@@ -1111,7 +1112,8 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
       }
 
       try {
-        final response = await http.get(Uri.parse(url));
+        final response =
+            await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final decoded = img.decodeImage(response.bodyBytes);
@@ -1121,6 +1123,9 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
             PdfImageCache.put(url, memImg);
           }
         }
+      } on TimeoutException catch (_) {
+        // ignore: avoid_print
+        print('Timeout fetching image from URL $url');
       } catch (e) {
         // ignore: avoid_print
         print('Error fetching image from URL $url: $e');

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -14,6 +14,7 @@ import 'package:mime/mime.dart';
 import 'package:intl/intl.dart';
 import 'dart:convert';
 import 'dart:ui' as ui; // For TextDirection
+import 'dart:async';
 
 import 'dart:typed_data';
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -3091,7 +3092,8 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       }
 
       try {
-        final response = await http.get(Uri.parse(url));
+        final response =
+            await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final decoded = img.decodeImage(response.bodyBytes);
@@ -3105,6 +3107,8 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         } else {
           print('Failed to load image from URL $url');
         }
+      } on TimeoutException catch (_) {
+        print('Timeout fetching image from URL $url');
       } catch (e) {
         print('Error fetching image from URL $url: $e');
       }

--- a/lib/utils/report_storage.dart
+++ b/lib/utils/report_storage.dart
@@ -23,7 +23,7 @@ class ReportStorage {
           // contentType: MediaType('application', 'pdf'), // قد تحتاج لإضافة هذا إذا كان الخادم يتطلب نوع المحتوى
         ));
 
-      var response = await request.send();
+      var response = await request.send().timeout(const Duration(seconds: 15));
 
       if (response.statusCode == 200) {
         final responseBody = await response.stream.bytesToString();
@@ -35,6 +35,9 @@ class ReportStorage {
         print('Error uploading PDF: ${response.statusCode}, $errorBody');
         return null;
       }
+    } on TimeoutException catch (_) {
+      print('PDF upload timed out');
+      return null;
     } catch (e) {
       print('Exception during PDF upload: $e');
       return null;
@@ -52,13 +55,17 @@ class ReportStorage {
   // دالة لتنزيل تقرير PDF
   static Future<Uint8List?> downloadReportPdf(String url) async {
     try {
-      final response = await http.get(Uri.parse(url));
+      final response =
+          await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
       if (response.statusCode == 200) {
         return response.bodyBytes;
       } else {
         print('Error downloading PDF: ${response.statusCode}');
         return null;
       }
+    } on TimeoutException catch (_) {
+      print('PDF download timed out');
+      return null;
     } catch (e) {
       print('Exception during PDF download: $e');
       return null;


### PR DESCRIPTION
## Summary
- add timeouts to PDF upload/download in `ReportStorage`
- add timeouts when fetching images for PDF generation

## Testing
- `git status --short`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517c49b41c832a9cba1364e5f471c5