### PR TITLE
Fix RTL table orientation in PDF reports

### DIFF
--- a/lib/pages/admin/admin_attendance_report_page.dart
+++ b/lib/pages/admin/admin_attendance_report_page.dart
@@ -917,6 +917,7 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
               font: _arabicFont!,
               headers: headers,
               data: dataRows,
+              isRtl: true,
             ),
             ...summaryWidgets
           ];

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -1709,6 +1709,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       font: font,
       headers: ['اسم القطعة', 'الكمية الإجمالية', 'الحالة'],
       data: data,
+      isRtl: true,
     );
   }
 

--- a/lib/utils/pdf_styles.dart
+++ b/lib/utils/pdf_styles.dart
@@ -74,6 +74,7 @@ class PdfStyles {
     required List<List<String>> data,
     PdfColor? headerColor,
     PdfColor? borderColor,
+    bool isRtl = false,
   }) {
     final PdfColor primary = headerColor ?? PdfColor.fromHex('#21206C');
     final PdfColor border = borderColor ?? PdfColors.grey300;
@@ -87,11 +88,17 @@ class PdfStyles {
     final pw.TextStyle cellStyle =
         pw.TextStyle(font: font, fontSize: 10, color: PdfColors.black);
 
+    // Reverse columns if right-to-left orientation is requested
+    final headerCells = isRtl ? headers.reversed.toList() : headers;
+    final dataRows = isRtl
+        ? data.map((row) => row.reversed.toList()).toList()
+        : data;
+
     final rows = <pw.TableRow>[];
     rows.add(
       pw.TableRow(
         decoration: pw.BoxDecoration(color: primary),
-        children: headers
+        children: headerCells
             .map((h) => pw.Padding(
                   padding: const pw.EdgeInsets.all(8),
                   child: pw.Text(
@@ -105,7 +112,7 @@ class PdfStyles {
       ),
     );
 
-    for (final row in data) {
+    for (final row in dataRows) {
       rows.add(
         pw.TableRow(
           children: row


### PR DESCRIPTION
## Summary
- ensure `PdfStyles.buildTable` can reverse columns for RTL
- render admin attendance and project detail tables in RTL order

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68518fbe3c8c832aa911576882b1c9ff