### PR TITLE
Add quick project creation from client list

### DIFF
--- a/lib/pages/admin/add_project_page.dart
+++ b/lib/pages/admin/add_project_page.dart
@@ -17,11 +17,17 @@ import '../../main.dart'; // Assuming helper functions are in main.dart
 class AddProjectPage extends StatefulWidget {
   final List<QueryDocumentSnapshot> availableEngineers;
   final List<QueryDocumentSnapshot> availableClients;
+  final String? initialClientId;
+  final String? defaultProjectName;
+  final bool lockClientSelection;
 
   const AddProjectPage({
     super.key,
     required this.availableEngineers,
     required this.availableClients,
+    this.initialClientId,
+    this.defaultProjectName,
+    this.lockClientSelection = false,
   });
 
   @override
@@ -43,6 +49,12 @@ class _AddProjectPageState extends State<AddProjectPage> {
   void initState() { // --- MODIFICATION: Added initState ---
     super.initState();
     _getCurrentAdminName(); // Fetch admin name when the page loads
+    if (widget.initialClientId != null) {
+      _selectedClientId = widget.initialClientId;
+    }
+    if (widget.defaultProjectName != null) {
+      _nameController.text = widget.defaultProjectName!;
+    }
   }
 
   // --- MODIFICATION START: Function to get current admin's name ---
@@ -334,11 +346,13 @@ class _AddProjectPageState extends State<AddProjectPage> {
                         child: Text(user['name'] ?? 'عميل غير مسمى'),
                       );
                     }).toList(),
-                    onChanged: (value) {
-                      setState(() {
-                        _selectedClientId = value;
-                      });
-                    },
+                    onChanged: widget.lockClientSelection
+                        ? null
+                        : (value) {
+                            setState(() {
+                              _selectedClientId = value;
+                            });
+                          },
                     validator: (value) {
                       if (value == null) {
                         return 'الرجاء اختيار العميل.';
@@ -347,6 +361,15 @@ class _AddProjectPageState extends State<AddProjectPage> {
                     },
                     isExpanded: true,
                     menuMaxHeight: MediaQuery.of(context).size.height * 0.3,
+                    disabledHint: Text(
+                      (widget.availableClients
+                                  .firstWhere(
+                                    (d) => d.id == _selectedClientId,
+                                    orElse: () => widget.availableClients.first,
+                                  )
+                                  .data() as Map<String, dynamic>)['name'] ??
+                          'عميل',
+                    ),
                   ),
 
                 const SizedBox(height: AppConstants.paddingLarge * 1.5),

--- a/lib/pages/admin/admin_clients_page.dart
+++ b/lib/pages/admin/admin_clients_page.dart
@@ -5,6 +5,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:engineer_management_system/theme/app_constants.dart';
 import 'dart:ui' as ui; // For TextDirection
+import 'add_project_page.dart';
 
 class AdminClientsPage extends StatefulWidget {
   const AdminClientsPage({super.key});
@@ -141,6 +142,38 @@ class _AdminClientsPageState extends State<AdminClientsPage> {
         _showFeedbackSnackBar(context, 'تم حذف العميل $email من قاعدة البيانات بنجاح.', isError: false);
       } catch (e) {
         _showFeedbackSnackBar(context, 'فشل حذف العميل: $e', isError: true);
+      }
+    }
+  }
+
+  Future<void> _createProjectForClient(DocumentSnapshot clientDoc) async {
+    try {
+      final engSnap = await FirebaseFirestore.instance
+          .collection('users')
+          .where('role', isEqualTo: 'engineer')
+          .orderBy('name')
+          .get();
+
+      if (!mounted) return;
+
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => AddProjectPage(
+            availableEngineers: engSnap.docs,
+            availableClients: [clientDoc],
+            initialClientId: clientDoc.id,
+            defaultProjectName:
+                (clientDoc.data() as Map<String, dynamic>)['name'] ?? '',
+            lockClientSelection: true,
+          ),
+        ),
+      );
+    } catch (e) {
+      if (mounted) {
+        _showFeedbackSnackBar(
+            context, 'فشل تحميل بيانات المهندسين: $e',
+            isError: true);
       }
     }
   }
@@ -629,6 +662,11 @@ class _AdminClientsPageState extends State<AdminClientsPage> {
                       ),
                     ],
                   ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add_business_outlined, color: AppConstants.primaryColor),
+                  onPressed: () => _createProjectForClient(clientDoc),
+                  tooltip: 'إنشاء مشروع لهذا العميل',
                 ),
                 // Edit Button
                 IconButton(


### PR DESCRIPTION
## Summary
- allow AddProjectPage to preselect client and default name
- enable AddProjectPage to lock client dropdown when needed
- fetch engineers and open AddProjectPage from the clients page
- add button on each client row to create a project quickly

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857dd108db8832a8a3431122d4a42a0