### PR TITLE
Add popup menus for edit/delete

### DIFF
--- a/lib/pages/admin/admin_clients_page.dart
+++ b/lib/pages/admin/admin_clients_page.dart
@@ -668,16 +668,41 @@ class _AdminClientsPageState extends State<AdminClientsPage> {
                   onPressed: () => _createProjectForClient(clientDoc),
                   tooltip: 'إنشاء مشروع لهذا العميل',
                 ),
-                // Edit Button
-                IconButton(
-                  icon: const Icon(Icons.edit_outlined, color: AppConstants.infoColor),
-                  onPressed: () => _showEditClientDialog(clientDoc), // Pass the DocumentSnapshot
-                  tooltip: 'تعديل العميل',
-                ),
-                IconButton(
-                  icon: const Icon(Icons.delete_outline, color: AppConstants.deleteColor),
-                  onPressed: () => _deleteClient(uid, email),
-                  tooltip: 'حذف العميل',
+                PopupMenuButton<String>(
+                  icon: const Icon(Icons.more_vert),
+                  tooltip: 'خيارات',
+                  onSelected: (value) {
+                    switch (value) {
+                      case 'edit':
+                        _showEditClientDialog(clientDoc);
+                        break;
+                      case 'delete':
+                        _deleteClient(uid, email);
+                        break;
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    PopupMenuItem(
+                      value: 'edit',
+                      child: Row(
+                        children: const [
+                          Icon(Icons.edit_outlined, color: AppConstants.infoColor),
+                          SizedBox(width: 8),
+                          Text('تعديل العميل'),
+                        ],
+                      ),
+                    ),
+                    PopupMenuItem(
+                      value: 'delete',
+                      child: Row(
+                        children: const [
+                          Icon(Icons.delete_outline, color: AppConstants.deleteColor),
+                          SizedBox(width: 8),
+                          Text('حذف العميل'),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/pages/admin/admin_employees_page.dart
+++ b/lib/pages/admin/admin_employees_page.dart
@@ -567,15 +567,41 @@ class _AdminEmployeesPageState extends State<AdminEmployeesPage> {
                     ],
                   ),
                 ),
-                IconButton(
-                  icon: const Icon(Icons.edit_outlined, color: AppConstants.infoColor, size: 26),
-                  onPressed: () => _showEditEmployeeDialog(emp),
-                  tooltip: 'تعديل الموظف',
-                ),
-                IconButton(
-                  icon: const Icon(Icons.delete_outline_rounded, color: AppConstants.deleteColor, size: 26),
-                  onPressed: () => _deleteEmployee(uid, email), //
-                  tooltip: 'حذف الموظف',
+                PopupMenuButton<String>(
+                  icon: const Icon(Icons.more_vert),
+                  tooltip: 'خيارات',
+                  onSelected: (value) {
+                    switch (value) {
+                      case 'edit':
+                        _showEditEmployeeDialog(emp);
+                        break;
+                      case 'delete':
+                        _deleteEmployee(uid, email);
+                        break;
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    PopupMenuItem(
+                      value: 'edit',
+                      child: Row(
+                        children: const [
+                          Icon(Icons.edit_outlined, color: AppConstants.infoColor, size: 26),
+                          SizedBox(width: 8),
+                          Text('تعديل الموظف'),
+                        ],
+                      ),
+                    ),
+                    PopupMenuItem(
+                      value: 'delete',
+                      child: Row(
+                        children: const [
+                          Icon(Icons.delete_outline_rounded, color: AppConstants.deleteColor, size: 26),
+                          SizedBox(width: 8),
+                          Text('حذف الموظف'),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/pages/admin/admin_engineers_page.dart
+++ b/lib/pages/admin/admin_engineers_page.dart
@@ -504,15 +504,41 @@ class _AdminEngineersPageState extends State<AdminEngineersPage> {
                     ],
                   ),
                 ),
-                IconButton(
-                  icon: const Icon(Icons.edit_outlined, color: AppConstants.infoColor),
-                  onPressed: () => _showEditEngineerDialog(engineer),
-                  tooltip: 'تعديل المهندس',
-                ),
-                IconButton(
-                  icon: const Icon(Icons.delete_outline, color: AppConstants.deleteColor),
-                  onPressed: () => _deleteEngineer(uid, email),
-                  tooltip: 'حذف المهندس',
+                PopupMenuButton<String>(
+                  icon: const Icon(Icons.more_vert),
+                  tooltip: 'خيارات',
+                  onSelected: (value) {
+                    switch (value) {
+                      case 'edit':
+                        _showEditEngineerDialog(engineer);
+                        break;
+                      case 'delete':
+                        _deleteEngineer(uid, email);
+                        break;
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    PopupMenuItem(
+                      value: 'edit',
+                      child: Row(
+                        children: const [
+                          Icon(Icons.edit_outlined, color: AppConstants.infoColor),
+                          SizedBox(width: 8),
+                          Text('تعديل المهندس'),
+                        ],
+                      ),
+                    ),
+                    PopupMenuItem(
+                      value: 'delete',
+                      child: Row(
+                        children: const [
+                          Icon(Icons.delete_outline, color: AppConstants.deleteColor),
+                          SizedBox(width: 8),
+                          Text('حذف المهندس'),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- simplify engineer list item actions with a popup menu
- use popup menu for employee list actions
- move client list edit/delete actions into a popup menu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857df67dc6c832aa429594d501445ea