### PR TITLE
Fix TooManyPagesException by increasing PDF page limit

### DIFF
--- a/lib/utils/part_request_pdf_generator.dart
+++ b/lib/utils/part_request_pdf_generator.dart
@@ -57,6 +57,7 @@ class PartRequestPdfGenerator {
     final pdf = pw.Document();
     pdf.addPage(
       pw.MultiPage(
+        maxPages: 500,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -292,6 +292,7 @@ class PdfReportGenerator {
 
     pdf.addPage(
       pw.MultiPage(
+        maxPages: 500,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,
@@ -1028,6 +1029,7 @@ class PdfReportGenerator {
 
     pdf.addPage(
       pw.MultiPage(
+        maxPages: 500,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,


### PR DESCRIPTION
## Summary
- increase max page count on all PDF generation to prevent `TooManyPagesException`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bd9342e18832ab14b756c47fbfdd8