### PR TITLE
Fix Arabic font usage in generated PDFs

### DIFF
--- a/lib/pages/admin/admin_attendance_report_page.dart
+++ b/lib/pages/admin/admin_attendance_report_page.dart
@@ -863,7 +863,12 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,
           theme: pw.ThemeData.withFont(
-              base: _arabicFont, fontFallback: commonFontFallback),
+            base: _arabicFont,
+            bold: _arabicFont,
+            italic: _arabicFont,
+            boldItalic: _arabicFont,
+            fontFallback: commonFontFallback,
+          ),
           margin: PdfStyles.pageMargins,
         ),
         header: (context) => PdfStyles.buildHeader(

--- a/lib/pages/admin/admin_evaluations_page.dart
+++ b/lib/pages/admin/admin_evaluations_page.dart
@@ -1340,7 +1340,13 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,
-          theme: pw.ThemeData.withFont(base: _arabicFont, fontFallback: commonFontFallback),
+          theme: pw.ThemeData.withFont(
+            base: _arabicFont,
+            bold: _arabicFont,
+            italic: _arabicFont,
+            boldItalic: _arabicFont,
+            fontFallback: commonFontFallback,
+          ),
           margin: PdfStyles.pageMargins,
         ),
         header: (context) => PdfStyles.buildHeader(

--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1168,8 +1168,13 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,
-          theme:
-              pw.ThemeData.withFont(base: _arabicFont, fontFallback: commonFontFallback),
+          theme: pw.ThemeData.withFont(
+            base: _arabicFont,
+            bold: _arabicFont,
+            italic: _arabicFont,
+            boldItalic: _arabicFont,
+            fontFallback: commonFontFallback,
+          ),
           margin: PdfStyles.pageMargins,
         ),
         header: (context) => PdfStyles.buildHeader(

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1211,8 +1211,13 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,
-          theme:
-              pw.ThemeData.withFont(base: _arabicFont, fontFallback: commonFontFallback),
+          theme: pw.ThemeData.withFont(
+            base: _arabicFont,
+            bold: _arabicFont,
+            italic: _arabicFont,
+            boldItalic: _arabicFont,
+            fontFallback: commonFontFallback,
+          ),
           margin: PdfStyles.pageMargins,
         ),
         header: (context) => PdfStyles.buildHeader(

--- a/lib/utils/part_request_pdf_generator.dart
+++ b/lib/utils/part_request_pdf_generator.dart
@@ -61,7 +61,12 @@ class PartRequestPdfGenerator {
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,
-          theme: pw.ThemeData.withFont(base: _arabicFont!),
+          theme: pw.ThemeData.withFont(
+            base: _arabicFont!,
+            bold: _arabicFont!,
+            italic: _arabicFont!,
+            boldItalic: _arabicFont!,
+          ),
           margin: PdfStyles.pageMargins,
         ),
         header: (context) => PdfStyles.buildHeader(

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -530,7 +530,13 @@ class PdfReportGenerator {
 
           textDirection: pw.TextDirection.rtl,
 
-          theme: pw.ThemeData.withFont(base: _arabicFont, fontFallback: commonFontFallback),
+          theme: pw.ThemeData.withFont(
+            base: _arabicFont,
+            bold: _arabicFont,
+            italic: _arabicFont,
+            boldItalic: _arabicFont,
+            fontFallback: commonFontFallback,
+          ),
 
           margin: PdfStyles.pageMargins,
 
@@ -1891,7 +1897,12 @@ class PdfReportGenerator {
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,
-          theme: pw.ThemeData.withFont(base: _arabicFont),
+          theme: pw.ThemeData.withFont(
+            base: _arabicFont,
+            bold: _arabicFont,
+            italic: _arabicFont,
+            boldItalic: _arabicFont,
+          ),
           // Provide some spacing on the sides since there is no header or footer
           margin: const pw.EdgeInsets.symmetric(horizontal: 25, vertical: 20),
         ),


### PR DESCRIPTION
## Summary
- update PDF generation to supply the same Arabic font for bold/italic styles
- apply the change across all PDF generators and report pages

## Testing
- `dart format lib/utils/pdf_report_generator.dart lib/utils/part_request_pdf_generator.dart lib/pages/admin/admin_evaluations_page.dart lib/pages/admin/admin_meeting_logs_page.dart lib/pages/admin/admin_attendance_report_page.dart lib/pages/engineer/meeting_logs_page.dart` *(fails: `dart: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685bf1917e98832aa6b79f0ee340ee71