### PR TITLE
Add WhatsApp sharing to client phone

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -177,17 +177,18 @@ class MyApp extends StatelessWidget {
           }
           return const LoginPage();
         },
-        '/pdf_preview': (context) {
-          final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>?;
-          if (args != null && args['bytes'] != null && args['fileName'] != null && args['text'] != null) {
-            return PdfPreviewScreen(
-              pdfBytes: args['bytes'] as Uint8List,
-              fileName: args['fileName'] as String,
-              shareText: args['text'] as String,
-            );
-          }
-          return const Scaffold(body: Center(child: Text('لا يمكن عرض الملف')));
-        },
+          '/pdf_preview': (context) {
+            final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>?;
+            if (args != null && args['bytes'] != null && args['fileName'] != null && args['text'] != null) {
+              return PdfPreviewScreen(
+                pdfBytes: args['bytes'] as Uint8List,
+                fileName: args['fileName'] as String,
+                shareText: args['text'] as String,
+                clientPhone: args['phone'] as String?,
+              );
+            }
+            return const Scaffold(body: Center(child: Text('لا يمكن عرض الملف')));
+          },
         // --- ADDITION START ---
         '/admin/evaluations': (context) => const AdminEvaluationsPage(), // مسار جديد لصفحة التقييم
         '/admin/meeting_logs': (context) => const AdminMeetingLogsPage(),

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -2022,6 +2022,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
+      'phone': _clientPhone,
     });
   }
 

--- a/lib/pages/common/pdf_preview_screen.dart
+++ b/lib/pages/common/pdf_preview_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:printing/printing.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:whatsapp_share2/whatsapp_share2.dart';
 
 import '../../theme/app_constants.dart';
 
@@ -13,24 +14,46 @@ class PdfPreviewScreen extends StatelessWidget {
   final Uint8List pdfBytes;
   final String fileName;
   final String shareText;
+  final String? clientPhone;
 
   const PdfPreviewScreen({
     Key? key,
     required this.pdfBytes,
     required this.fileName,
     required this.shareText,
+    this.clientPhone,
   }) : super(key: key);
 
   Future<void> _sharePdf(BuildContext context) async {
     if (kIsWeb) {
-      await Share.shareXFiles([XFile.fromData(pdfBytes, name: fileName, mimeType: 'application/pdf')], text: shareText);
-    } else {
-      final dir = await getTemporaryDirectory();
-      final path = '${dir.path}/$fileName';
-      final file = File(path);
-      await file.writeAsBytes(pdfBytes, flush: true);
-      await Share.shareXFiles([XFile(path)], text: shareText);
+      await Share.shareXFiles(
+        [XFile.fromData(pdfBytes, name: fileName, mimeType: 'application/pdf')],
+        text: shareText,
+      );
+      return;
     }
+
+    final dir = await getTemporaryDirectory();
+    final path = '${dir.path}/$fileName';
+    final file = File(path);
+    await file.writeAsBytes(pdfBytes, flush: true);
+
+    if (clientPhone != null && clientPhone!.isNotEmpty) {
+      var normalized = clientPhone!.replaceAll(RegExp(r'[^0-9]'), '');
+      if (normalized.startsWith('0')) {
+        normalized = '966${normalized.substring(1)}';
+      }
+      try {
+        await WhatsappShare.shareFile(
+          phone: normalized,
+          text: shareText,
+          filePath: path,
+        );
+        return;
+      } catch (_) {}
+    }
+
+    await Share.shareXFiles([XFile(path)], text: shareText);
   }
 
   @override

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -3668,6 +3668,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
+      'phone': _clientPhone,
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   http: ^1.2.1 #
   url_launcher: ^6.2.2 #
   share_plus: ^8.0.0 #
+  whatsapp_share2: ^2.0.0 #
   google_maps_flutter: ^2.5.0 #
   firebase_core_web: ^2.0.0 #
   pdf: ^3.10.4 #


### PR DESCRIPTION
## Summary
- support direct WhatsApp share in PDF preview
- pass client phone to preview screen
- enable phone-based sharing for project details pages
- register phone argument for preview route
- add `whatsapp_share2` dependency

## Testing
- `dart format -o none lib/pages/common/pdf_preview_screen.dart` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c00ba8d88832ab987c1a10984687c