### PR TITLE
Remove whatsapp_share2 plugin to fix Android build

### DIFF
--- a/lib/pages/common/pdf_preview_screen.dart
+++ b/lib/pages/common/pdf_preview_screen.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:printing/printing.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
-import 'package:whatsapp_share2/whatsapp_share2.dart';
 
 import '../../theme/app_constants.dart';
 
@@ -37,21 +36,6 @@ class PdfPreviewScreen extends StatelessWidget {
     final path = '${dir.path}/$fileName';
     final file = File(path);
     await file.writeAsBytes(pdfBytes, flush: true);
-
-    if (clientPhone != null && clientPhone!.isNotEmpty) {
-      var normalized = clientPhone!.replaceAll(RegExp(r'[^0-9]'), '');
-      if (normalized.startsWith('0')) {
-        normalized = '966${normalized.substring(1)}';
-      }
-      try {
-        await WhatsappShare.shareFile(
-          phone: normalized,
-          text: shareText,
-          filePath: path,
-        );
-        return;
-      } catch (_) {}
-    }
 
     await Share.shareXFiles([XFile(path)], text: shareText);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
   http: ^1.2.1 #
   url_launcher: ^6.2.2 #
   share_plus: ^8.0.0 #
-  whatsapp_share2: ^2.0.0 #
   google_maps_flutter: ^2.5.0 #
   firebase_core_web: ^2.0.0 #
   pdf: ^3.10.4 #


### PR DESCRIPTION
## Summary
- remove the outdated `whatsapp_share2` dependency from `pubspec.yaml`
- drop plugin usage in `PdfPreviewScreen` and rely on `share_plus`

These changes avoid a Gradle build failure caused by the `whatsapp_share2` plugin missing an Android `namespace` definition.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c39dc6d28832aa1cd56112ae78e41