### PR TITLE
Handle empty project details table

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -726,6 +726,10 @@ class PdfReportGenerator {
       pw.TextStyle valueStyle,
       PdfColor headerColor,
       PdfColor borderColor) {
+    if (details.isEmpty) {
+      return pw.SizedBox.shrink();
+    }
+
     final headers = details.keys.toList();
     final values = details.values.toList();
     return pw.Table(


### PR DESCRIPTION
## Summary
- avoid building an empty table in PDF generation

## Testing
- `dart format lib/utils/pdf_report_generator.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c3cdc884c832ab9c1446afc2ffbd3