### PR TITLE
Fix namespace issue for whatsapp_share2 plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,15 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// Workaround for plugins missing a namespace definition when using AGP 8+
+subprojects {
+    afterEvaluate { project ->
+        if (project.name == 'whatsapp_share2' && project.hasProperty('android')) {
+            project.android.namespace = 'com.whatsapp.share2'
+        }
+    }
+}
+
 
 tasks.register("clean", Delete) {
     delete rootProject.buildDir


### PR DESCRIPTION
## Summary
- workaround plugin missing namespace by setting it in `android/build.gradle`

## Testing
- `flutter test` *(fails: command not found)*
- `dart format -o none --set-exit-if-changed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c45f36608832aac1443214dd9ecfd