### PR TITLE
Fix Android build script afterEvaluate issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,10 +25,12 @@ subprojects {
 }
 
 // Workaround for plugins missing a namespace definition when using AGP 8+
-subprojects {
-    afterEvaluate { project ->
-        if (project.name == 'whatsapp_share2' && project.hasProperty('android')) {
-            project.android.namespace = 'com.whatsapp.share2'
+subprojects { project ->
+    if (project.name == 'whatsapp_share2') {
+        project.plugins.withId('com.android.library') {
+            if (project.hasProperty('android')) {
+                project.android.namespace = 'com.whatsapp.share2'
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix `Cannot run Project.afterEvaluate(Closure)` error by applying plugin hook

## Testing
- `gradle assembleDebug -p android` *(fails: `/workspace/engineer_management_system/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_685c478a7748832a8a37b8120b83ba33