### PR TITLE
Fix WhatsApp Share compileSdk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,17 @@ subprojects { project ->
         project.plugins.withId('com.android.library') {
             if (project.hasProperty('android')) {
                 project.android.namespace = 'com.whatsapp.share2'
+                // Ensure the plugin is compiled with a recent SDK to avoid
+                // missing attributes like android:attr/lStar.
+                project.android.compileSdkVersion = 33
+                project.android.defaultConfig.with {
+                    if (hasProperty('targetSdk')) {
+                        targetSdk = 33
+                    }
+                    if (hasProperty('targetSdkVersion')) {
+                        targetSdkVersion = 33
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- adjust android build script so the whatsapp_share2 plugin compiles with SDK 33

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c4d269ec4832a8224b8656556179f