### PR TITLE
Fix whatsapp_share2 build issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,8 +32,16 @@ subprojects { project ->
                 project.android.namespace = 'com.whatsapp.share2'
                 // Ensure the plugin is compiled with a recent SDK to avoid
                 // missing attributes like android:attr/lStar.
-                project.android.compileSdkVersion = 33
+                if (project.android.hasProperty('compileSdk')) {
+                    project.android.compileSdk = 33
+                }
+                if (project.android.hasProperty('compileSdkVersion')) {
+                    project.android.compileSdkVersion = 33
+                }
                 project.android.defaultConfig.with {
+                    if (hasProperty('minSdk')) {
+                        minSdk = Math.max(minSdk as int, 21)
+                    }
                     if (hasProperty('targetSdk')) {
                         targetSdk = 33
                     }


### PR DESCRIPTION
## Summary
- force the whatsapp_share2 plugin to use a newer compile SDK
- ensure target SDK is also bumped for the plugin

## Testing
- `./gradlew --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c4e6166c4832ab107e9b48607c4f1