### PR TITLE
Improve web settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To set up and run the project locally, follow these steps:
         * Follow Firebase instructions to add `GoogleService-Info.plist` to your Xcode project.
     * **For Web**:
         * Add a Web app to your Firebase project.
-        * Update `web/index.html` with your project's `firebaseConfig` information (if `flutterfire configure` didn't do it automatically). Ensure `apiKey` and `appId` in `lib/firebase_options.dart` also match web settings.
+        * Create a `web/firebase-config.js` file containing your project's `firebaseConfig` object and ensure `web/index.html` includes this script. The keys should match the values in `lib/firebase_options.dart`.
     * **For All Platforms**: Run the following command to generate the `firebase_options.dart` file:
         ```bash
         flutterfire configure

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,15 +48,7 @@ void main() async {
   //   print('Firebase app [DEFAULT] already initialized.');
   // }
   await Firebase.initializeApp(
-    options: const FirebaseOptions(
-      apiKey: "AIzaSyDX_fhBTQmwm-KP8Qu2gfwFQylGuaEm4VA",
-      authDomain: "eng-system.firebaseapp.com",
-      projectId: "eng-system",
-      storageBucket: "eng-system.firebasestorage.app",
-      messagingSenderId: "526461382833",
-      appId: "1:526461382833:web:46090faa13de2d4b30f290",
-      measurementId: "G-NMMTY5PN4Y",
-    ),
+    options: DefaultFirebaseOptions.currentPlatform,
   );
 
 

--- a/web/firebase-config.js
+++ b/web/firebase-config.js
@@ -1,0 +1,9 @@
+window.firebaseConfig = {
+  apiKey: "AIzaSyDX_fhBTQmwm-KP8Qu2gfwFQylGuaEm4VA",
+  authDomain: "eng-system.firebaseapp.com",
+  projectId: "eng-system",
+  storageBucket: "eng-system.firebasestorage.app",
+  messagingSenderId: "526461382833",
+  appId: "1:526461382833:web:46090faa13de2d4b30f290",
+  measurementId: "G-NMMTY5PN4Y"
+};

--- a/web/index.html
+++ b/web/index.html
@@ -25,19 +25,10 @@
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-storage-compat.js"></script>
 
-  <!-- Firebase Configuration -->
+  <script src="firebase-config.js"></script>
   <script>
     window.onload = function () {
-      const firebaseConfig = {
-        apiKey: "AIzaSyDX_fhBTQmwm-KP8Qu2gfwFQylGuaEm4VA",
-      authDomain: "eng-system.firebaseapp.com",
-      projectId: "eng-system",
-      storageBucket: "eng-system.firebasestorage.app",
-      messagingSenderId: "526461382833",
-      appId: "1:526461382833:web:46090faa13de2d4b30f290",
-      measurementId: "G-NMMTY5PN4Y",
-      };
-      firebase.initializeApp(firebaseConfig);
+      firebase.initializeApp(window.firebaseConfig);
     };
 
     // Placeholder for the Google Maps init callback


### PR DESCRIPTION
## Summary
- load Firebase config from a dedicated `firebase-config.js`
- switch Flutter initialization to use `DefaultFirebaseOptions`
- update README with web configuration instructions

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610fbb7450832aa2ca5a76086b4361