### PR TITLE
Add engineers to existing projects

### DIFF
--- a/lib/pages/admin/admin_engineers_page.dart
+++ b/lib/pages/admin/admin_engineers_page.dart
@@ -216,6 +216,21 @@ class _AdminEngineersPageState extends State<AdminEngineersPage> {
                         'createdAt': FieldValue.serverTimestamp(),
                       });
 
+                      // Add the newly created engineer to all existing projects
+                      final Map<String, String> newEngineerData = {
+                        'uid': userCred.user!.uid,
+                        'name': nameController.text.trim(),
+                      };
+                      final projectsSnapshot = await FirebaseFirestore.instance
+                          .collection('projects')
+                          .get();
+                      for (final project in projectsSnapshot.docs) {
+                        await project.reference.update({
+                          'assignedEngineers': FieldValue.arrayUnion([newEngineerData]),
+                          'engineerUids': FieldValue.arrayUnion([userCred.user!.uid]),
+                        });
+                      }
+
                       Navigator.pop(dialogContext);
                       _showFeedbackSnackBar(context, 'تم إضافة المهندس بنجاح.', isError: false);
                     } on FirebaseAuthException catch (e) {


### PR DESCRIPTION
## Summary
- automatically assign a newly created engineer to all current projects

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a30a533c832a8465a6122d34bb2e