### PR TITLE
Add WhatsApp direct PDF share

### DIFF
--- a/lib/pages/common/pdf_preview_screen.dart
+++ b/lib/pages/common/pdf_preview_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:printing/printing.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:whatsapp_share2/whatsapp_share2.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../theme/app_constants.dart';
@@ -43,10 +44,20 @@ class PdfPreviewScreen extends StatelessWidget {
       if (normalized.startsWith('0')) {
         normalized = '966${normalized.substring(1)}';
       }
-      final url = Uri.parse(
-          'https://wa.me/$normalized?text=${Uri.encodeComponent(shareText)}');
-      if (await canLaunchUrl(url)) {
-        await launchUrl(url, mode: LaunchMode.externalApplication);
+
+      try {
+        await WhatsappShare.shareFile(
+          phone: normalized,
+          text: shareText,
+          filePath: path,
+        );
+        return;
+      } catch (_) {
+        final url = Uri.parse(
+            'https://wa.me/$normalized?text=${Uri.encodeComponent(shareText)}');
+        if (await canLaunchUrl(url)) {
+          await launchUrl(url, mode: LaunchMode.externalApplication);
+        }
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   http: ^1.2.1 #
   url_launcher: ^6.2.2 #
   share_plus: ^8.0.0 #
+  whatsapp_share2: ^2.0.4 #
   google_maps_flutter: ^2.5.0 #
   firebase_core_web: ^2.0.0 #
   pdf: ^3.10.4 #


### PR DESCRIPTION
## Summary
- allow sharing PDF directly to client's WhatsApp number
- add `whatsapp_share2` dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a4316258832abe1fd7d30dcdcf2e