### PR TITLE
Use share_plus for WhatsApp sharing

### DIFF
--- a/lib/pages/common/pdf_preview_screen.dart
+++ b/lib/pages/common/pdf_preview_screen.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:printing/printing.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
-import 'package:whatsapp_share2/whatsapp_share2.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../theme/app_constants.dart';
@@ -38,28 +37,6 @@ class PdfPreviewScreen extends StatelessWidget {
     final path = '${dir.path}/$fileName';
     final file = File(path);
     await file.writeAsBytes(pdfBytes, flush: true);
-
-    if (clientPhone != null && clientPhone!.isNotEmpty) {
-      var normalized = clientPhone!.replaceAll(RegExp(r'[^0-9]'), '');
-      if (normalized.startsWith('0')) {
-        normalized = '966${normalized.substring(1)}';
-      }
-
-      try {
-        await WhatsappShare.shareFile(
-          phone: normalized,
-          text: shareText,
-          filePath: path,
-        );
-        return;
-      } catch (_) {
-        final url = Uri.parse(
-            'https://wa.me/$normalized?text=${Uri.encodeComponent(shareText)}');
-        if (await canLaunchUrl(url)) {
-          await launchUrl(url, mode: LaunchMode.externalApplication);
-        }
-      }
-    }
 
     await Share.shareXFiles([XFile(path)], text: shareText);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
   http: ^1.2.1 #
   url_launcher: ^6.2.2 #
   share_plus: ^8.0.0 #
-  whatsapp_share2: ^2.0.4 #
   google_maps_flutter: ^2.5.0 #
   firebase_core_web: ^2.0.0 #
   pdf: ^3.10.4 #


### PR DESCRIPTION
## Summary
- remove `whatsapp_share2` dependency
- share PDFs using `share_plus` instead of WhatsappShare

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a577233c832a86c757eae2cd0ed3