### PR TITLE
Fix share_plus web compile issue

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -772,7 +772,7 @@ packages:
       sha256: fb5319f3aab4c5dda5ebb92dca978179ba21f8c783ee4380910ef4c1c6824f51
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "9.0.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -987,7 +987,7 @@ packages:
     source: hosted
     version: "14.3.0"
   web:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   image_picker: ^1.1.0 #
   http: ^1.2.1 #
   url_launcher: ^6.2.2 #
-  share_plus: ^8.0.0 #
+  share_plus: ^9.0.0 #
   google_maps_flutter: ^2.5.0 #
   firebase_core_web: ^2.0.0 #
   pdf: ^3.10.4 #
@@ -92,5 +92,3 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/to/font-from-package
-dependency_overrides:
-    web: ^1.0.0  # أجبر استخدام الإصدار الجديد


### PR DESCRIPTION
## Summary
- remove `web` dependency override
- upgrade `share_plus` to latest major version

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ad2c39d0832aac0f5944b4705ece