### PR TITLE
Add basic finance module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ A comprehensive system for managing projects, engineers, clients, and employees,
     * Evaluation system for engineers based on criteria such as working hours, completed tasks, and activity rate.
     * Set different weights for evaluation criteria by the Admin.
     * Enable automatic monthly and yearly evaluations.
+* **Financial Management**:
+    * Review sales and spare part orders for approval.
+    * Manage debts, payments and collections.
+    * Record purchases and link them to maintenance and production costs.
 * **Attachments and Important Notes Management**:
     * Add important notes and attachments to projects.
 * **Holiday Settings**:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:engineer_management_system/pages/admin/admin_meeting_logs_page.d
 import 'package:engineer_management_system/pages/admin/admin_materials_page.dart';
 import 'package:engineer_management_system/pages/common/change_password_page.dart';
 import 'package:engineer_management_system/pages/common/pdf_preview_screen.dart';
+import 'package:engineer_management_system/pages/admin/admin_finance_page.dart';
 
 // --- ADDITION START ---
 import 'package:engineer_management_system/pages/admin/admin_evaluations_page.dart'; // استيراد صفحة التقييم الجديدة
@@ -186,6 +187,7 @@ class MyApp extends StatelessWidget {
         '/admin/evaluations': (context) => const AdminEvaluationsPage(), // مسار جديد لصفحة التقييم
         '/admin/meeting_logs': (context) => const AdminMeetingLogsPage(),
         '/admin/materials': (context) => const AdminMaterialsPage(),
+        '/admin/finance': (context) => const AdminFinancePage(),
         // --- ADDITION END ---
       },
 

--- a/lib/models/finance_models.dart
+++ b/lib/models/finance_models.dart
@@ -1,0 +1,108 @@
+// lib/models/finance_models.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Represents a sales or spare part order that requires financial approval.
+class FinancialRequest {
+  final String id;
+  final String type; // e.g. "sale", "sparePart"
+  final String description;
+  final double amount;
+  final String status; // pending, approved, rejected
+
+  FinancialRequest({
+    required this.id,
+    required this.type,
+    required this.description,
+    required this.amount,
+    required this.status,
+  });
+
+  factory FinancialRequest.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>? ?? {};
+    return FinancialRequest(
+      id: doc.id,
+      type: data['type'] as String? ?? '',
+      description: data['description'] as String? ?? '',
+      amount: (data['amount'] as num?)?.toDouble() ?? 0.0,
+      status: data['status'] as String? ?? 'pending',
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'type': type,
+      'description': description,
+      'amount': amount,
+      'status': status,
+    };
+  }
+}
+
+/// Represents a debt entry with payments and remaining balance.
+class DebtEntry {
+  final String id;
+  final String customerName;
+  final double total;
+  final double paid;
+
+  DebtEntry({
+    required this.id,
+    required this.customerName,
+    required this.total,
+    required this.paid,
+  });
+
+  double get remaining => total - paid;
+
+  factory DebtEntry.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>? ?? {};
+    return DebtEntry(
+      id: doc.id,
+      customerName: data['customerName'] as String? ?? '',
+      total: (data['total'] as num?)?.toDouble() ?? 0.0,
+      paid: (data['paid'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'customerName': customerName,
+      'total': total,
+      'paid': paid,
+    };
+  }
+}
+
+/// Represents a purchase linked to maintenance or production cost.
+class PurchaseRecord {
+  final String id;
+  final String description;
+  final double cost;
+  final String relatedProjectId;
+
+  PurchaseRecord({
+    required this.id,
+    required this.description,
+    required this.cost,
+    required this.relatedProjectId,
+  });
+
+  factory PurchaseRecord.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>? ?? {};
+    return PurchaseRecord(
+      id: doc.id,
+      description: data['description'] as String? ?? '',
+      cost: (data['cost'] as num?)?.toDouble() ?? 0.0,
+      relatedProjectId: data['relatedProjectId'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'description': description,
+      'cost': cost,
+      'relatedProjectId': relatedProjectId,
+    };
+  }
+}
+

--- a/lib/pages/admin/admin_dashboard.dart
+++ b/lib/pages/admin/admin_dashboard.dart
@@ -767,6 +767,13 @@ class _AdminDashboardState extends State<AdminDashboard> with TickerProviderStat
         route: '/admin/meeting_logs',
       ),
       _ManagementItem(
+        title: 'الوحدة المالية',
+        subtitle: 'مراجعة الطلبات والتحصيل',
+        icon: Icons.account_balance_wallet,
+        color: const Color(0xFF10B981),
+        route: '/admin/finance',
+      ),
+      _ManagementItem(
         title: 'الإعدادات العامة',
         subtitle: 'إعدادات النظام',
         icon: Icons.settings_rounded,

--- a/lib/pages/admin/admin_finance_page.dart
+++ b/lib/pages/admin/admin_finance_page.dart
@@ -1,0 +1,185 @@
+// lib/pages/admin/admin_finance_page.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import '../../models/finance_models.dart';
+import '../../theme/app_constants.dart';
+
+/// A simple dashboard for managing financial requests, debts and purchases.
+class AdminFinancePage extends StatefulWidget {
+  const AdminFinancePage({super.key});
+
+  @override
+  State<AdminFinancePage> createState() => _AdminFinancePageState();
+}
+
+class _AdminFinancePageState extends State<AdminFinancePage> {
+  late final CollectionReference requestsRef;
+  late final CollectionReference debtsRef;
+  late final CollectionReference purchasesRef;
+
+  @override
+  void initState() {
+    super.initState();
+    requestsRef = FirebaseFirestore.instance.collection('financial_requests');
+    debtsRef = FirebaseFirestore.instance.collection('debts');
+    purchasesRef = FirebaseFirestore.instance.collection('purchases');
+  }
+
+  Future<void> approveRequest(String id) async {
+    await requestsRef.doc(id).update({'status': 'approved'});
+  }
+
+  Future<void> rejectRequest(String id) async {
+    await requestsRef.doc(id).update({'status': 'rejected'});
+  }
+
+  Widget _buildRequests() {
+    return StreamBuilder<QuerySnapshot>(
+      stream: requestsRef.where('status', isEqualTo: 'pending').snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final docs = snapshot.data?.docs ?? [];
+        if (docs.isEmpty) {
+          return const Center(child: Text('لا توجد طلبات قيد المراجعة'));
+        }
+        return ListView.separated(
+          itemCount: docs.length,
+          separatorBuilder: (_, __) => const Divider(),
+          itemBuilder: (context, index) {
+            final request = FinancialRequest.fromFirestore(docs[index]);
+            return ListTile(
+              title: Text(request.description),
+              subtitle: Text('${request.amount.toStringAsFixed(2)} - ${request.type}'),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.check, color: AppConstants.successColor),
+                    onPressed: () => approveRequest(request.id),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close, color: AppConstants.deleteColor),
+                    onPressed: () => rejectRequest(request.id),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildDebts() {
+    return StreamBuilder<QuerySnapshot>(
+      stream: debtsRef.snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final docs = snapshot.data?.docs ?? [];
+        if (docs.isEmpty) {
+          return const Center(child: Text('لا توجد مديونيات')); 
+        }
+        return ListView.separated(
+          itemCount: docs.length,
+          separatorBuilder: (_, __) => const Divider(),
+          itemBuilder: (context, index) {
+            final debt = DebtEntry.fromFirestore(docs[index]);
+            return ListTile(
+              title: Text(debt.customerName),
+              subtitle: Text('المتبقي: ${debt.remaining.toStringAsFixed(2)}'),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildPurchases() {
+    return StreamBuilder<QuerySnapshot>(
+      stream: purchasesRef.snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final docs = snapshot.data?.docs ?? [];
+        if (docs.isEmpty) {
+          return const Center(child: Text('لا توجد مشتريات')); 
+        }
+        return ListView.separated(
+          itemCount: docs.length,
+          separatorBuilder: (_, __) => const Divider(),
+          itemBuilder: (context, index) {
+            final purchase = PurchaseRecord.fromFirestore(docs[index]);
+            return ListTile(
+              title: Text(purchase.description),
+              subtitle: Text('التكلفة: ${purchase.cost.toStringAsFixed(2)}'),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 3,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('الوحدة المالية'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'الطلبات'),
+              Tab(text: 'المديونيات'),
+              Tab(text: 'المشتريات'),
+            ],
+          ),
+        ),
+        body: const TabBarView(
+          children: [
+            // Widgets are built lazily using functions below
+            _RequestsTab(),
+            _DebtsTab(),
+            _PurchasesTab(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Wrappers to allow using functions defined above in TabBarView
+class _RequestsTab extends StatelessWidget {
+  const _RequestsTab();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.findAncestorStateOfType<_AdminFinancePageState>()!;
+    return state._buildRequests();
+  }
+}
+
+class _DebtsTab extends StatelessWidget {
+  const _DebtsTab();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.findAncestorStateOfType<_AdminFinancePageState>()!;
+    return state._buildDebts();
+  }
+}
+
+class _PurchasesTab extends StatelessWidget {
+  const _PurchasesTab();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.findAncestorStateOfType<_AdminFinancePageState>()!;
+    return state._buildPurchases();
+  }
+}
+


### PR DESCRIPTION
## Summary
- add finance data models
- create admin finance management page
- link finance page in admin dashboard and route
- document new financial management features

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f2a3903c832a86fa415b4d07b9f6