### PR TITLE
Fix PDF page limit

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -510,7 +510,7 @@ class PdfReportGenerator {
     pdf.addPage(
 
       pw.MultiPage(
-
+        maxPages: 500,
         pageTheme: pw.PageTheme(
 
           pageFormat: PdfPageFormat.a4,
@@ -1811,6 +1811,7 @@ class PdfReportGenerator {
 
     pdf.addPage(
       pw.MultiPage(
+        maxPages: 500,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,


### PR DESCRIPTION
## Summary
- allow generating daily report PDFs with more than the default page limit

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d027984ac832a859859ae38e70708