### PR TITLE
Increase PDF page limit

### DIFF
--- a/lib/pages/admin/admin_attendance_report_page.dart
+++ b/lib/pages/admin/admin_attendance_report_page.dart
@@ -859,6 +859,7 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
 
     pdf.addPage(
       pw.MultiPage(
+        maxPages: 1000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/pages/admin/admin_evaluations_page.dart
+++ b/lib/pages/admin/admin_evaluations_page.dart
@@ -1337,6 +1337,7 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
 
     pdf.addPage(
       pw.MultiPage(
+        maxPages: 1000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1165,6 +1165,7 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
 
     pdf.addPage(
       pw.MultiPage(
+        maxPages: 1000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1208,6 +1208,7 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
 
     pdf.addPage(
       pw.MultiPage(
+        maxPages: 1000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -3798,6 +3798,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
 
     pdf.addPage(
         pw.MultiPage(
+            maxPages: 1000,
             pageTheme: pw.PageTheme(
               pageFormat: PdfPageFormat.a4,
               orientation: pw.PageOrientation.portrait,

--- a/lib/utils/part_request_pdf_generator.dart
+++ b/lib/utils/part_request_pdf_generator.dart
@@ -57,7 +57,7 @@ class PartRequestPdfGenerator {
     final pdf = pw.Document();
     pdf.addPage(
       pw.MultiPage(
-        maxPages: 500,
+        maxPages: 1000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -510,7 +510,7 @@ class PdfReportGenerator {
     pdf.addPage(
 
       pw.MultiPage(
-        maxPages: 500,
+        maxPages: 1000,
         pageTheme: pw.PageTheme(
 
           pageFormat: PdfPageFormat.a4,
@@ -1811,7 +1811,7 @@ class PdfReportGenerator {
 
     pdf.addPage(
       pw.MultiPage(
-        maxPages: 500,
+        maxPages: 1000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,


### PR DESCRIPTION
## Summary
- bump `maxPages` limit on all `MultiPage` PDF generators to 1000

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d045fa978832a86b403e15a30cdf2