### PR TITLE
Fix OOM during PDF generation

### DIFF
--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -18,6 +18,7 @@ import 'package:image/image.dart' as img;
 import '../../utils/pdf_styles.dart';
 import '../../utils/pdf_image_cache.dart';
 import '../../utils/report_storage.dart';
+import '../../utils/pdf_report_generator.dart';
 import 'package:engineer_management_system/html_stub.dart'
     if (dart.library.html) 'dart:html' as html;
 import 'package:intl/intl.dart';
@@ -1071,12 +1072,11 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
             await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
-          final decoded = img.decodeImage(response.bodyBytes);
-          if (decoded != null) {
-            final memImg = pw.MemoryImage(response.bodyBytes);
-            fetched[url] = memImg;
-            PdfImageCache.put(url, memImg);
-          }
+          final resizedBytes =
+              PdfReportGenerator.resizeImageForTest(response.bodyBytes);
+          final memImg = pw.MemoryImage(resizedBytes);
+          fetched[url] = memImg;
+          PdfImageCache.put(url, memImg);
         }
       } on TimeoutException catch (_) {
         print('Timeout fetching image from URL $url');

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1981,15 +1981,14 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
 
       try {
         final response =
-        await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
+            await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
-          final decoded = img.decodeImage(response.bodyBytes);
-          if (decoded != null) {
-            final memImg = pw.MemoryImage(response.bodyBytes);
-            fetched[url] = memImg;
-            PdfImageCache.put(url, memImg);
-          }
+          final resizedBytes =
+              PdfReportGenerator.resizeImageForTest(response.bodyBytes);
+          final memImg = pw.MemoryImage(resizedBytes);
+          fetched[url] = memImg;
+          PdfImageCache.put(url, memImg);
         }
       } on TimeoutException catch (_) {
         print('Timeout fetching image from URL $url');

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -20,6 +20,7 @@ import 'package:image/image.dart' as img;
 import '../../utils/pdf_styles.dart';
 import '../../utils/pdf_image_cache.dart';
 import '../../utils/report_storage.dart';
+import '../../utils/pdf_report_generator.dart';
 import 'package:engineer_management_system/html_stub.dart'
     if (dart.library.html) 'dart:html' as html;
 import 'dart:convert';
@@ -1117,12 +1118,11 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
             await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
-          final decoded = img.decodeImage(response.bodyBytes);
-          if (decoded != null) {
-            final memImg = pw.MemoryImage(response.bodyBytes);
-            fetched[url] = memImg;
-            PdfImageCache.put(url, memImg);
-          }
+          final resizedBytes =
+              PdfReportGenerator.resizeImageForTest(response.bodyBytes);
+          final memImg = pw.MemoryImage(resizedBytes);
+          fetched[url] = memImg;
+          PdfImageCache.put(url, memImg);
         }
       } on TimeoutException catch (_) {
         // ignore: avoid_print

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -3334,14 +3334,11 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
             await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
-          final decoded = img.decodeImage(response.bodyBytes);
-          if (decoded != null) {
-            final memImg = pw.MemoryImage(response.bodyBytes);
-            fetched[url] = memImg;
-            PdfImageCache.put(url, memImg);
-          } else {
-            print('Invalid image bytes for URL $url');
-          }
+          final resizedBytes =
+              PdfReportGenerator.resizeImageForTest(response.bodyBytes);
+          final memImg = pw.MemoryImage(resizedBytes);
+          fetched[url] = memImg;
+          PdfImageCache.put(url, memImg);
         } else {
           print('Failed to load image from URL $url');
         }

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -1,0 +1,15 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:engineer_management_system/utils/pdf_report_generator.dart';
+import 'package:image/image.dart' as img;
+
+void main() {
+  test('resizeImageForTest shrinks large image', () {
+    final image = img.Image(width: 2000, height: 2000); // Solid image
+    final bytes = Uint8List.fromList(img.encodeJpg(image));
+    final resized = PdfReportGenerator.resizeImageForTest(bytes);
+    final decoded = img.decodeImage(resized)!;
+    expect(decoded.width <= 1024, true);
+    expect(decoded.height <= 1024, true);
+  });
+}


### PR DESCRIPTION
## Summary
- resize downloaded images before embedding them in PDFs
- expose resizeImageForTest helper
- import PdfReportGenerator in pages and use resizing logic
- add regression test for resizing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d06ecc6c4832a94b9598ad6637117