### PR TITLE
Improve PDF generator memory usage

### DIFF
--- a/lib/utils/part_request_pdf_generator.dart
+++ b/lib/utils/part_request_pdf_generator.dart
@@ -54,7 +54,8 @@ class PartRequestPdfGenerator {
       ]);
     }
 
-    final pdf = pw.Document();
+    // Compress the PDF output to keep memory usage under control
+    final pdf = pw.Document(compress: true);
     pdf.addPage(
       pw.MultiPage(
         maxPages: 10000,

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -30,7 +30,8 @@ import 'report_storage.dart';
 class PdfReportGenerator {
 
   static pw.Font? _arabicFont;
-  static const int _maxImageDimension = 1024;
+  // Limit the dimensions of any embedded images to keep memory usage low
+  static const int _maxImageDimension = 720;
 
 
   static Future<void> _loadArabicFont() async {
@@ -65,7 +66,9 @@ class PdfReportGenerator {
       width: widthLarger ? _maxImageDimension : null,
       height: widthLarger ? null : _maxImageDimension,
     );
-    return Uint8List.fromList(img.encodeJpg(resized, quality: 85));
+    // Compress further to avoid excessive memory consumption when building
+    // very large reports.
+    return Uint8List.fromList(img.encodeJpg(resized, quality: 70));
   }
 
   @visibleForTesting
@@ -422,7 +425,8 @@ class PdfReportGenerator {
     if (emojiFont != null) commonFontFallback.add(emojiFont);
 
 
-    final pdf = pw.Document();
+    // Enable compression on the PDF document to reduce memory usage
+    final pdf = pw.Document(compress: true);
 
     final fileName =
 
@@ -1811,7 +1815,8 @@ class PdfReportGenerator {
       throw Exception('Arabic font not available');
     }
 
-    final pdf = pw.Document();
+    // Enable compression on the PDF document to reduce memory usage
+    final pdf = pw.Document(compress: true);
     final fileName =
         'simple_report_${DateFormat('yyyyMMdd_HHmmss').format(now)}.pdf';
     final token = generateReportToken();

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -9,7 +9,8 @@ void main() {
     final bytes = Uint8List.fromList(img.encodeJpg(image));
     final resized = PdfReportGenerator.resizeImageForTest(bytes);
     final decoded = img.decodeImage(resized)!;
-    expect(decoded.width <= 1024, true);
-    expect(decoded.height <= 1024, true);
+    // Images should be resized down to the configured maximum dimension
+    expect(decoded.width <= 720, true);
+    expect(decoded.height <= 720, true);
   });
 }


### PR DESCRIPTION
## Summary
- optimize PDF image resizing to limit dimensions and apply stronger compression
- enable compression on generated PDF documents
- adjust part request PDF generation similarly
- update unit tests for new image size limits

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1bed5304832ab687e247707e7caf