### PR TITLE
Increase timeouts for PDF image fetching

### DIFF
--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1068,8 +1068,9 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
       }
 
       try {
-        final response =
-            await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
+        final response = await http
+            .get(Uri.parse(url))
+            .timeout(const Duration(seconds: 60));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final resizedBytes =

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1980,8 +1980,9 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
       }
 
       try {
-        final response =
-            await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
+        final response = await http
+            .get(Uri.parse(url))
+            .timeout(const Duration(seconds: 60));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final resizedBytes =

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1114,8 +1114,9 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
       }
 
       try {
-        final response =
-            await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
+        final response = await http
+            .get(Uri.parse(url))
+            .timeout(const Duration(seconds: 60));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final resizedBytes =

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -3330,8 +3330,9 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       }
 
       try {
-        final response =
-            await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
+        final response = await http
+            .get(Uri.parse(url))
+            .timeout(const Duration(seconds: 60));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final resizedBytes =

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -89,7 +89,9 @@ class PdfReportGenerator {
       }
       try {
         final response =
-            await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
+            await http
+                .get(Uri.parse(url))
+                .timeout(const Duration(seconds: 60));
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final resizedBytes = _resizeImageIfNeeded(response.bodyBytes);

--- a/lib/utils/report_storage.dart
+++ b/lib/utils/report_storage.dart
@@ -24,7 +24,9 @@ class ReportStorage {
           // contentType: MediaType('application', 'pdf'), // قد تحتاج لإضافة هذا إذا كان الخادم يتطلب نوع المحتوى
         ));
 
-      var response = await request.send().timeout(const Duration(seconds: 15));
+      var response = await request
+          .send()
+          .timeout(const Duration(seconds: 60));
 
       if (response.statusCode == 200) {
         final responseBody = await response.stream.bytesToString();
@@ -56,8 +58,9 @@ class ReportStorage {
   // دالة لتنزيل تقرير PDF
   static Future<Uint8List?> downloadReportPdf(String url) async {
     try {
-      final response =
-          await http.get(Uri.parse(url)).timeout(const Duration(seconds: 15));
+      final response = await http
+          .get(Uri.parse(url))
+          .timeout(const Duration(seconds: 60));
       if (response.statusCode == 200) {
         return response.bodyBytes;
       } else {


### PR DESCRIPTION
## Summary
- allow more time when fetching remote images for PDF generation
- extend timeouts for admin and engineer views
- bump upload/download limits in report storage

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1dbc3d2c832a8df2ee660d06db16