### PR TITLE
Lower PDF image resolution to reduce memory usage

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -31,7 +31,10 @@ class PdfReportGenerator {
 
   static pw.Font? _arabicFont;
   // Limit the dimensions of any embedded images to keep memory usage low
-  static const int _maxImageDimension = 720;
+  // Lower the maximum image dimension to significantly reduce memory usage
+  // during PDF generation. This helps prevent "Out of Memory" issues when
+  // many high resolution images are included in the report.
+  static const int _maxImageDimension = 512;
 
 
   static Future<void> _loadArabicFont() async {

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -10,7 +10,7 @@ void main() {
     final resized = PdfReportGenerator.resizeImageForTest(bytes);
     final decoded = img.decodeImage(resized)!;
     // Images should be resized down to the configured maximum dimension
-    expect(decoded.width <= 720, true);
-    expect(decoded.height <= 720, true);
+    expect(decoded.width <= 512, true);
+    expect(decoded.height <= 512, true);
   });
 }


### PR DESCRIPTION
## Summary
- compress embedded images more to avoid OOM issues
- adjust tests for the new size limit

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d21179520832a8ee288556740dd63