### PR TITLE
Improve PDF memory usage

### DIFF
--- a/lib/utils/pdf_image_cache.dart
+++ b/lib/utils/pdf_image_cache.dart
@@ -1,12 +1,31 @@
+import 'dart:collection';
 import "package:pdf/widgets.dart" as pw;
+
+/// Simple LRU cache for [pw.MemoryImage] objects used while generating PDFs.
+///
+/// Limiting the number of cached images helps keep the memory footprint
+/// manageable when many images are included in a single report.
 class PdfImageCache {
   PdfImageCache._();
 
-  static final Map<String, pw.MemoryImage> _cache = {};
+  static final LinkedHashMap<String, pw.MemoryImage> _cache = LinkedHashMap();
+  // Maximum number of images to keep in memory at any time.
+  static const int _maxEntries = 100;
 
-  static pw.MemoryImage? get(String url) => _cache[url];
+  static pw.MemoryImage? get(String url) {
+    final img = _cache.remove(url);
+    if (img != null) {
+      // Re-insert to mark as most recently used.
+      _cache[url] = img;
+    }
+    return img;
+  }
 
   static void put(String url, pw.MemoryImage image) {
+    if (_cache.length >= _maxEntries) {
+      // Remove the oldest entry (first item in the map).
+      _cache.remove(_cache.keys.first);
+    }
     _cache[url] = image;
   }
 

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -34,7 +34,8 @@ class PdfReportGenerator {
   // Lower the maximum image dimension to significantly reduce memory usage
   // during PDF generation. This helps prevent "Out of Memory" issues when
   // many high resolution images are included in the report.
-  static const int _maxImageDimension = 512;
+  // Reduced further to allow handling many images without exhausting memory.
+  static const int _maxImageDimension = 256;
 
 
   static Future<void> _loadArabicFont() async {
@@ -71,7 +72,7 @@ class PdfReportGenerator {
     );
     // Compress further to avoid excessive memory consumption when building
     // very large reports.
-    return Uint8List.fromList(img.encodeJpg(resized, quality: 70));
+    return Uint8List.fromList(img.encodeJpg(resized, quality: 60));
   }
 
   @visibleForTesting

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -10,7 +10,7 @@ void main() {
     final resized = PdfReportGenerator.resizeImageForTest(bytes);
     final decoded = img.decodeImage(resized)!;
     // Images should be resized down to the configured maximum dimension
-    expect(decoded.width <= 512, true);
-    expect(decoded.height <= 512, true);
+    expect(decoded.width <= 256, true);
+    expect(decoded.height <= 256, true);
   });
 }


### PR DESCRIPTION
## Summary
- optimize memory usage when generating PDFs
- limit in-memory image cache with an LRU strategy
- lower resized image size and compression
- update tests for new limits

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d22e1a1d8832a88064cc6cf8c9027