### PR TITLE
Reduce memory usage for PDF generation

### DIFF
--- a/lib/utils/pdf_image_cache.dart
+++ b/lib/utils/pdf_image_cache.dart
@@ -9,8 +9,9 @@ class PdfImageCache {
   PdfImageCache._();
 
   static final LinkedHashMap<String, pw.MemoryImage> _cache = LinkedHashMap();
-  // Maximum number of images to keep in memory at any time.
-  static const int _maxEntries = 100;
+  // Maximum number of images to keep in memory at any time. Reducing the
+  // cache size lowers peak memory usage when a report contains many photos.
+  static const int _maxEntries = 50;
 
   static pw.MemoryImage? get(String url) {
     final img = _cache.remove(url);

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -35,7 +35,9 @@ class PdfReportGenerator {
   // during PDF generation. This helps prevent "Out of Memory" issues when
   // many high resolution images are included in the report.
   // Reduced further to allow handling many images without exhausting memory.
-  static const int _maxImageDimension = 256;
+  // The previous value of 256 still caused issues in low memory devices, so
+  // we shrink images down to 128px on the longest side.
+  static const int _maxImageDimension = 128;
 
 
   static Future<void> _loadArabicFont() async {
@@ -72,7 +74,9 @@ class PdfReportGenerator {
     );
     // Compress further to avoid excessive memory consumption when building
     // very large reports.
-    return Uint8List.fromList(img.encodeJpg(resized, quality: 60));
+    // Save with slightly lower quality to further reduce memory usage while
+    // keeping reasonable visual fidelity.
+    return Uint8List.fromList(img.encodeJpg(resized, quality: 50));
   }
 
   @visibleForTesting

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -10,7 +10,7 @@ void main() {
     final resized = PdfReportGenerator.resizeImageForTest(bytes);
     final decoded = img.decodeImage(resized)!;
     // Images should be resized down to the configured maximum dimension
-    expect(decoded.width <= 256, true);
-    expect(decoded.height <= 256, true);
+    expect(decoded.width <= 128, true);
+    expect(decoded.height <= 128, true);
   });
 }


### PR DESCRIPTION
## Summary
- lower cached image count and max dimension when generating PDFs
- compress images a bit more before embedding
- update image resize test to reflect new limit

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d245c83ec832ab725fac1240bd29f