### PR TITLE
Optimize image compression for PDF generation

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -35,9 +35,9 @@ class PdfReportGenerator {
   // during PDF generation. This helps prevent "Out of Memory" issues when
   // many high resolution images are included in the report.
   // Reduced further to allow handling many images without exhausting memory.
-  // The previous value of 256 still caused issues in low memory devices, so
-  // we shrink images down to 128px on the longest side.
-  static const int _maxImageDimension = 128;
+  // Even 128px on the longest side proved large when dozens of images are
+  // embedded, so we compress images down to 96px on the longest side.
+  static const int _maxImageDimension = 96;
 
 
   static Future<void> _loadArabicFont() async {
@@ -73,10 +73,9 @@ class PdfReportGenerator {
       height: widthLarger ? null : _maxImageDimension,
     );
     // Compress further to avoid excessive memory consumption when building
-    // very large reports.
-    // Save with slightly lower quality to further reduce memory usage while
-    // keeping reasonable visual fidelity.
-    return Uint8List.fromList(img.encodeJpg(resized, quality: 50));
+    // very large reports. Save with lower quality to further reduce memory
+    // usage while keeping reasonable visual fidelity.
+    return Uint8List.fromList(img.encodeJpg(resized, quality: 40));
   }
 
   @visibleForTesting

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -10,7 +10,7 @@ void main() {
     final resized = PdfReportGenerator.resizeImageForTest(bytes);
     final decoded = img.decodeImage(resized)!;
     // Images should be resized down to the configured maximum dimension
-    expect(decoded.width <= 128, true);
-    expect(decoded.height <= 128, true);
+    expect(decoded.width <= 96, true);
+    expect(decoded.height <= 96, true);
   });
 }


### PR DESCRIPTION
## Summary
- compress images more when generating PDFs to reduce memory usage
- update unit tests for new compression settings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d263dea8c832a8880e8a8e3622844