### PR TITLE
Fix onProgress undefined

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -1596,7 +1596,10 @@ class PdfReportGenerator {
     required List<Map<String, dynamic>> testsStructure,
     DateTime? start,
     DateTime? end,
+    void Function(double progress)? onProgress,
   }) async {
+    PdfImageCache.clear();
+    onProgress?.call(0.0);
     DateTime now = DateTime.now();
     bool useRange = start != null || end != null;
     if (useRange) {


### PR DESCRIPTION
## Summary
- add `onProgress` parameter to `generateSimpleTables`
- call `onProgress` when starting generation

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686d328d644c832aa0cc99c54d5963c8