### PR TITLE
Improve PDF image handling

### DIFF
--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -4,10 +4,10 @@ import 'package:engineer_management_system/utils/pdf_report_generator.dart';
 import 'package:image/image.dart' as img;
 
 void main() {
-  test('resizeImageForTest shrinks large image', () {
+  test('resizeImageForTest shrinks large image', () async {
     final image = img.Image(width: 2000, height: 2000); // Solid image
     final bytes = Uint8List.fromList(img.encodeJpg(image));
-    final resized = PdfReportGenerator.resizeImageForTest(bytes);
+    final resized = await PdfReportGenerator.resizeImageForTest(bytes);
     final decoded = img.decodeImage(resized)!;
     // Images should be resized down to the configured maximum dimension
     expect(decoded.width, lessThanOrEqualTo(96));


### PR DESCRIPTION
## Summary
- compress images using Flutter codec to reduce memory usage
- update helper to return Future
- tweak pdf tests for async

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib/utils/pdf_report_generator.dart test/pdf_report_generator_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4427dfd4832a8535a0a60709c90c