### PR TITLE
Fix async image resizing and update image API

### DIFF
--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1074,7 +1074,7 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final resizedBytes =
-              PdfReportGenerator.resizeImageForTest(response.bodyBytes);
+              await PdfReportGenerator.resizeImageForTest(response.bodyBytes);
           final memImg = pw.MemoryImage(resizedBytes);
           fetched[url] = memImg;
           PdfImageCache.put(url, memImg);

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1988,7 +1988,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final resizedBytes =
-              PdfReportGenerator.resizeImageForTest(response.bodyBytes);
+              await PdfReportGenerator.resizeImageForTest(response.bodyBytes);
           final memImg = pw.MemoryImage(resizedBytes);
           fetched[url] = memImg;
           PdfImageCache.put(url, memImg);

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1120,7 +1120,7 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final resizedBytes =
-              PdfReportGenerator.resizeImageForTest(response.bodyBytes);
+              await PdfReportGenerator.resizeImageForTest(response.bodyBytes);
           final memImg = pw.MemoryImage(resizedBytes);
           fetched[url] = memImg;
           PdfImageCache.put(url, memImg);

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -3338,7 +3338,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         final contentType = response.headers['content-type'] ?? '';
         if (response.statusCode == 200 && contentType.startsWith('image/')) {
           final resizedBytes =
-              PdfReportGenerator.resizeImageForTest(response.bodyBytes);
+              await PdfReportGenerator.resizeImageForTest(response.bodyBytes);
           final memImg = pw.MemoryImage(resizedBytes);
           fetched[url] = memImg;
           PdfImageCache.put(url, memImg);

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -78,9 +78,9 @@ class PdfReportGenerator {
         await image.toByteData(format: ui.ImageByteFormat.rawRgba);
     if (raw == null) return bytes;
     final img.Image converted = img.Image.fromBytes(
-      image.width,
-      image.height,
-      raw.buffer.asUint8List(),
+      width: image.width,
+      height: image.height,
+      bytes: raw.buffer.asUint8List(),
     );
     // Encode to JPEG with a lower quality to further reduce memory usage.
     return Uint8List.fromList(img.encodeJpg(converted, quality: _jpgQuality));


### PR DESCRIPTION
## Summary
- await image resize calls when fetching remote images
- update `Image.fromBytes` usage for new named parameters

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d45da7544832a81dcf1bca1cb250c