### PR TITLE
Fix ByteData type reference

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -74,7 +74,7 @@ class PdfReportGenerator {
     );
     final ui.FrameInfo frame = await codec.getNextFrame();
     final ui.Image image = frame.image;
-    final ui.ByteData? raw =
+    final ByteData? raw =
         await image.toByteData(format: ui.ImageByteFormat.rawRgba);
     if (raw == null) return bytes;
     final img.Image converted = img.Image.fromBytes(


### PR DESCRIPTION
## Summary
- correct `ByteData` reference in `pdf_report_generator.dart`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d481e1ad8832aa043c1158cd1017b