### PR TITLE
Fix ByteBuffer argument type

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -80,7 +80,7 @@ class PdfReportGenerator {
     final img.Image converted = img.Image.fromBytes(
       width: image.width,
       height: image.height,
-      bytes: raw.buffer.asUint8List(),
+      bytes: raw.buffer,
     );
     // Encode to JPEG with a lower quality to further reduce memory usage.
     return Uint8List.fromList(img.encodeJpg(converted, quality: _jpgQuality));


### PR DESCRIPTION
## Summary
- pass `ByteBuffer` to `Image.fromBytes`

## Testing
- `flutter test` *(fails: flutter not found)*
- `dart analyze` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4a04ab40832a93d122940373be56