### PR TITLE
Disable PDF compression and size limits

### DIFF
--- a/lib/pages/admin/admin_attendance_report_page.dart
+++ b/lib/pages/admin/admin_attendance_report_page.dart
@@ -859,7 +859,7 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
 
     pdf.addPage(
       pw.MultiPage(
-        maxPages: 10000,
+        maxPages: 1000000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/pages/admin/admin_evaluations_page.dart
+++ b/lib/pages/admin/admin_evaluations_page.dart
@@ -1337,7 +1337,7 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
 
     pdf.addPage(
       pw.MultiPage(
-        maxPages: 10000,
+        maxPages: 1000000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1166,7 +1166,7 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
 
     pdf.addPage(
       pw.MultiPage(
-        maxPages: 10000,
+        maxPages: 1000000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1209,7 +1209,7 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
 
     pdf.addPage(
       pw.MultiPage(
-        maxPages: 10000,
+        maxPages: 1000000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -3798,7 +3798,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
 
     pdf.addPage(
         pw.MultiPage(
-            maxPages: 10000,
+            maxPages: 1000000,
             pageTheme: pw.PageTheme(
               pageFormat: PdfPageFormat.a4,
               orientation: pw.PageOrientation.portrait,

--- a/lib/utils/part_request_pdf_generator.dart
+++ b/lib/utils/part_request_pdf_generator.dart
@@ -54,11 +54,11 @@ class PartRequestPdfGenerator {
       ]);
     }
 
-    // Compress the PDF output to keep memory usage under control
-    final pdf = pw.Document(compress: true);
+    // Disable compression so images are embedded without modification
+    final pdf = pw.Document(compress: false);
     pdf.addPage(
       pw.MultiPage(
-        maxPages: 10000,
+        maxPages: 1000000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/utils/pdf_image_cache.dart
+++ b/lib/utils/pdf_image_cache.dart
@@ -11,7 +11,9 @@ class PdfImageCache {
   static final LinkedHashMap<String, pw.MemoryImage> _cache = LinkedHashMap();
   // Maximum number of images to keep in memory at any time. Reducing the
   // cache size lowers peak memory usage when a report contains many photos.
-  static const int _maxEntries = 50;
+  // Allow a very large number of cached images so reports can include
+  // unlimited photos without eviction.
+  static const int _maxEntries = 1000000;
 
   static pw.MemoryImage? get(String url) {
     final img = _cache.remove(url);
@@ -24,8 +26,8 @@ class PdfImageCache {
 
   static void put(String url, pw.MemoryImage image) {
     if (_cache.length >= _maxEntries) {
-      // Remove the oldest entry (first item in the map).
-      _cache.remove(_cache.keys.first);
+      // When the cache reaches the maximum size just keep adding entries.
+      // This effectively disables eviction.
     }
     _cache[url] = image;
   }

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -4,13 +4,13 @@ import 'package:engineer_management_system/utils/pdf_report_generator.dart';
 import 'package:image/image.dart' as img;
 
 void main() {
-  test('resizeImageForTest shrinks large image', () async {
+  test('resizeImageForTest returns original image when compression disabled', () async {
     final image = img.Image(width: 2000, height: 2000); // Solid image
     final bytes = Uint8List.fromList(img.encodeJpg(image));
     final resized = await PdfReportGenerator.resizeImageForTest(bytes);
     final decoded = img.decodeImage(resized)!;
-    // Images should be resized down to the configured maximum dimension
-    expect(decoded.width, lessThanOrEqualTo(96));
-    expect(decoded.height, lessThanOrEqualTo(96));
+    // Images are no longer resized or compressed
+    expect(decoded.width, equals(2000));
+    expect(decoded.height, equals(2000));
   });
 }


### PR DESCRIPTION
## Summary
- remove image resizing and compression in `PdfReportGenerator`
- disable PDF compression and allow unlimited pages across PDF generators
- expand PDF image cache capacity and stop evicting images
- update tests for new behavior

## Testing
- `flutter test` *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4ee9abf4832aac604f045d2e9973