### PR TITLE
Improve PDF generation stability

### DIFF
--- a/lib/utils/part_request_pdf_generator.dart
+++ b/lib/utils/part_request_pdf_generator.dart
@@ -54,11 +54,11 @@ class PartRequestPdfGenerator {
       ]);
     }
 
-    // Disable compression so images are embedded without modification
-    final pdf = pw.Document(compress: false);
+    // Enable compression to keep the generated document lightweight
+    final pdf = pw.Document(compress: true);
     pdf.addPage(
       pw.MultiPage(
-        maxPages: 1000000,
+        maxPages: 10000,
         pageTheme: pw.PageTheme(
           pageFormat: PdfPageFormat.a4,
           textDirection: pw.TextDirection.rtl,

--- a/lib/utils/pdf_image_cache.dart
+++ b/lib/utils/pdf_image_cache.dart
@@ -11,9 +11,7 @@ class PdfImageCache {
   static final LinkedHashMap<String, pw.MemoryImage> _cache = LinkedHashMap();
   // Maximum number of images to keep in memory at any time. Reducing the
   // cache size lowers peak memory usage when a report contains many photos.
-  // Allow a very large number of cached images so reports can include
-  // unlimited photos without eviction.
-  static const int _maxEntries = 1000000;
+  static const int _maxEntries = 200;
 
   static pw.MemoryImage? get(String url) {
     final img = _cache.remove(url);
@@ -26,8 +24,7 @@ class PdfImageCache {
 
   static void put(String url, pw.MemoryImage image) {
     if (_cache.length >= _maxEntries) {
-      // When the cache reaches the maximum size just keep adding entries.
-      // This effectively disables eviction.
+      _cache.remove(_cache.keys.first);
     }
     _cache[url] = image;
   }

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -4,13 +4,13 @@ import 'package:engineer_management_system/utils/pdf_report_generator.dart';
 import 'package:image/image.dart' as img;
 
 void main() {
-  test('resizeImageForTest returns original image when compression disabled', () async {
+  test('resizeImageForTest downscales large images', () async {
     final image = img.Image(width: 2000, height: 2000); // Solid image
     final bytes = Uint8List.fromList(img.encodeJpg(image));
     final resized = await PdfReportGenerator.resizeImageForTest(bytes);
     final decoded = img.decodeImage(resized)!;
-    // Images are no longer resized or compressed
-    expect(decoded.width, equals(2000));
-    expect(decoded.height, equals(2000));
+    // Images should be resized to at most 1024 pixels on the longest side
+    expect(decoded.width <= 1024, isTrue);
+    expect(decoded.height <= 1024, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- resize embedded images to 1024px with JPEG quality 75
- enable compression and set page limit to 10k pages
- add an LRU cache for PDF images with a maximum of 200 entries
- compress part request PDFs as well
- update tests for new resize behavior

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d87317648832ab29acd22ddc2db9f