### PR TITLE
Reduce PDF image memory consumption

### DIFF
--- a/lib/utils/pdf_image_cache.dart
+++ b/lib/utils/pdf_image_cache.dart
@@ -11,7 +11,7 @@ class PdfImageCache {
   static final LinkedHashMap<String, pw.MemoryImage> _cache = LinkedHashMap();
   // Maximum number of images to keep in memory at any time. Reducing the
   // cache size lowers peak memory usage when a report contains many photos.
-  static const int _maxEntries = 200;
+  static const int _maxEntries = 150;
 
   static pw.MemoryImage? get(String url) {
     final img = _cache.remove(url);

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -32,9 +32,9 @@ class PdfReportGenerator {
 
   static pw.Font? _arabicFont;
   // Limit the dimensions of embedded images so large photos do not cause
-  // out-of-memory errors when generating huge reports. A 1024px maximum keeps
-  // quality reasonable while dramatically reducing memory usage.
-  static const int _maxImageDimension = 1024;
+  // out-of-memory errors when generating huge reports. Lowering the limit
+  // further reduces peak memory usage when many images are embedded.
+  static const int _maxImageDimension = 512;
   // JPEG quality used when encoding resized images.
   static const int _jpgQuality = 75;
 

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -9,8 +9,8 @@ void main() {
     final bytes = Uint8List.fromList(img.encodeJpg(image));
     final resized = await PdfReportGenerator.resizeImageForTest(bytes);
     final decoded = img.decodeImage(resized)!;
-    // Images should be resized to at most 1024 pixels on the longest side
-    expect(decoded.width <= 1024, isTrue);
-    expect(decoded.height <= 1024, isTrue);
+    // Images should be resized to at most 512 pixels on the longest side
+    expect(decoded.width <= 512, isTrue);
+    expect(decoded.height <= 512, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- lower image dimension limit to reduce memory usage when generating PDFs
- cut PDF image cache size to prevent excessive memory retention
- adjust test expectations for new image resize limit

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e202e8170832a97225cbf1f027b45