### PR TITLE
Display four stats cards in a row on larger screens

### DIFF
--- a/lib/pages/admin/admin_dashboard.dart
+++ b/lib/pages/admin/admin_dashboard.dart
@@ -606,11 +606,12 @@ class _AdminDashboardState extends State<AdminDashboard> with TickerProviderStat
   }
 
   Widget _buildStatsGrid(double screenWidth) {
-    int crossAxisCount = 2; // Default for mobile and tablet
-    if (screenWidth >= _desktopBreakpoint) {
-      crossAxisCount = 4; // 4 columns for desktop
-    } else if (screenWidth >= _tabletBreakpoint) {
-      crossAxisCount = 2; // 2 columns for tablet, will spread
+    // Display all four cards in a single row on tablet and larger screens
+    int crossAxisCount;
+    if (screenWidth >= _tabletBreakpoint) {
+      crossAxisCount = 4; // Laptop/desktop/tablet
+    } else {
+      crossAxisCount = 2; // Mobile
     }
 
     // List of stat items without revenue


### PR DESCRIPTION
## Summary
- ensure stats cards in the admin dashboard overview render in a single row on tablet and larger screens

## Testing
- `flutter test` *(fails: `flutter` command not found)*
- `flutter analyze` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e246fff5c832a914d4d313504cc0d