### PR TITLE
Use white logo image in admin dashboard

### DIFF
--- a/lib/pages/admin/admin_dashboard.dart
+++ b/lib/pages/admin/admin_dashboard.dart
@@ -435,10 +435,10 @@ class _AdminDashboardState extends State<AdminDashboard> with TickerProviderStat
               color: Colors.white.withOpacity(0.2),
               borderRadius: BorderRadius.circular(50),
             ),
-            child: Icon(
-              Icons.dashboard_rounded,
-              size: iconSize,
-              color: Colors.white,
+            child: Image.asset(
+              'assets/images/white_logo.png',
+              width: iconSize,
+              height: iconSize,
             ),
           ),
           SizedBox(height: AppConstants.paddingMedium),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ flutter:
   assets:
     - assets/fonts/ # تأكد من أن هذا المسار صحيح إذا وضعت الخطوط في مجلد فرعي آخر داخل assets
     - assets/images/app_logo.png
+    - assets/images/white_logo.png
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
 


### PR DESCRIPTION
## Summary
- swap admin dashboard icon with white logo
- include white logo asset in pubspec

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e286641b0832a957a5d05e7ed9722