### PR TITLE
Add details tab in project pages

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -357,7 +357,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 6, vsync: this);
+    _tabController = TabController(length: 7, vsync: this);
     if (widget.notificationType != null && widget.highlightItemId != null) {
       final type = widget.notificationType!;
       if (type.contains('subphase')) {
@@ -790,6 +790,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         labelStyle: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16.5, fontFamily: 'Tajawal'),
         unselectedLabelStyle: const TextStyle(fontSize: 16, fontFamily: 'Tajawal'),
         tabs: const [
+          Tab(text: 'تفاصيل', icon: Icon(Icons.info_outline_rounded)),
           Tab(text: 'مراحل المشروع', icon: Icon(Icons.list_alt_rounded)),
           Tab(text: 'اختبارات التشغيل', icon: Icon(Icons.checklist_rtl_rounded)),
           Tab(text: 'طلبات المواد', icon: Icon(Icons.build_circle_outlined)),
@@ -948,6 +949,13 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildDetailsTab(Map<String, dynamic> projectDataMap) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(AppConstants.paddingMedium),
+      child: _buildProjectSummaryCard(projectDataMap),
     );
   }
 
@@ -3201,11 +3209,11 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         appBar: _buildAppBar(),
         body: Column(
           children: [
-            _buildProjectSummaryCard(projectDataMap),
             Expanded(
               child: TabBarView(
                 controller: _tabController,
                 children: [
+                  _buildDetailsTab(projectDataMap),
                   _buildPhasesTab(),
                   _buildTestsTab(),
                   _buildPartRequestsTab(),

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -337,7 +337,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 6, vsync: this);
+    _tabController = TabController(length: 7, vsync: this);
     _currentEngineerUid = FirebaseAuth.instance.currentUser?.uid;
     if (widget.notificationType != null && widget.highlightItemId != null) {
       final type = widget.notificationType!;
@@ -1587,6 +1587,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         labelColor: Colors.white,
         unselectedLabelColor: Colors.white70,
         tabs: const [
+          Tab(text: 'تفاصيل', icon: Icon(Icons.info_outline_rounded)),
           Tab(text: 'مراحل المشروع', icon: Icon(Icons.list_alt_rounded)),
           Tab(text: 'اختبارات التشغيل', icon: Icon(Icons.checklist_rtl_rounded)),
           Tab(text: 'طلبات المواد', icon: Icon(Icons.build_circle_outlined)),
@@ -1716,6 +1717,13 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildDetailsTab(Map<String, dynamic> projectDataMap) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(AppConstants.paddingMedium),
+      child: _buildProjectSummaryCard(projectDataMap),
     );
   }
 
@@ -2153,12 +2161,14 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         appBar: _buildAppBar(),
         body: Column(
           children: [
-            if (_projectDataSnapshot != null && _projectDataSnapshot!.exists)
-              _buildProjectSummaryCard(_projectDataSnapshot!.data() as Map<String, dynamic>),
             Expanded(
               child: TabBarView(
                 controller: _tabController,
                 children: [
+                  if (_projectDataSnapshot != null && _projectDataSnapshot!.exists)
+                    _buildDetailsTab(_projectDataSnapshot!.data() as Map<String, dynamic>)
+                  else
+                    const SizedBox.shrink(),
                   _buildPhasesTab(),
                   _buildTestsTab(),
                   _buildMaterialRequestsTab(),


### PR DESCRIPTION
## Summary
- show project info card in a dedicated tab on admin project page
- show project info card in a dedicated tab on engineer project page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e2a8ffcb0832a864333c6dec9c080