### PR TITLE
Improve loading dialog for PDF reports

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1912,7 +1912,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         onProgress: (p) => progress.value = p,
       );
 
-      ProgressDialog.hide(context);
+      await ProgressDialog.hide(context);
       _showFeedbackSnackBar(context, 'تم إنشاء التقرير بنجاح.', isError: false);
 
       _openPdfPreview(
@@ -1921,7 +1921,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         'يرجى الإطلاع على $headerText للمشروع.',
       );
     } catch (e) {
-      ProgressDialog.hide(context);
+      await ProgressDialog.hide(context);
       _showFeedbackSnackBar(context, 'فشل إنشاء أو مشاركة التقرير: $e', isError: true);
       print('Error generating daily report PDF: $e');
     }

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -987,7 +987,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         onProgress: (p) => progress.value = p,
       );
 
-      ProgressDialog.hide(context);
+      await ProgressDialog.hide(context);
       _showFeedbackSnackBar(context, getLocalizedText('تم إنشاء التقرير بنجاح.', 'Report generated successfully.'), isError: false);
       _openPdfPreview(
         pdfBytes,
@@ -995,7 +995,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         getLocalizedText('يرجى الإطلاع على التقرير للمشروع.', 'Please review the project report.'),
       );
     } catch (e) {
-      ProgressDialog.hide(context);
+      await ProgressDialog.hide(context);
       _showFeedbackSnackBar(context, getLocalizedText('فشل إنشاء أو مشاركة التقرير: $e', 'Failed to generate or share report: $e'), isError: true);
       print('Error generating daily report PDF: $e');
     }

--- a/lib/utils/progress_dialog.dart
+++ b/lib/utils/progress_dialog.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 import '../theme/app_constants.dart';
 
 class ProgressDialog {
+  static DateTime? _shownAt;
+  static const Duration _minDisplayDuration = Duration(seconds: 1);
+
   static ValueNotifier<double> show(BuildContext context, String message) {
     final notifier = ValueNotifier<double>(0);
+    _shownAt = DateTime.now();
     showDialog(
       context: context,
       barrierDismissible: false,
@@ -35,7 +39,14 @@ class ProgressDialog {
     return notifier;
   }
 
-  static void hide(BuildContext context) {
-    Navigator.of(context, rootNavigator: true).pop();
+  static Future<void> hide(BuildContext context) async {
+    final elapsed = DateTime.now().difference(_shownAt ?? DateTime.now());
+    final remaining = _minDisplayDuration - elapsed;
+    if (remaining > Duration.zero) {
+      await Future.delayed(remaining);
+    }
+    if (Navigator.of(context, rootNavigator: true).canPop()) {
+      Navigator.of(context, rootNavigator: true).pop();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- ensure progress dialog remains visible for at least one second
- await progress dialog hiding when generating PDF reports

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e306e8db8832aa9d76ee0f181d36e