### PR TITLE
Enable sharing PDF reports via links

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -178,6 +178,7 @@ class MyApp extends StatelessWidget {
                 fileName: args['fileName'] as String,
                 shareText: args['text'] as String,
                 clientPhone: args['phone'] as String?,
+                shareLink: args['link'] as String?,
               );
             }
             return const Scaffold(body: Center(child: Text('لا يمكن عرض الملف')));

--- a/lib/pages/admin/admin_attendance_report_page.dart
+++ b/lib/pages/admin/admin_attendance_report_page.dart
@@ -814,11 +814,13 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
     }
   }
 
-  void _openPdfPreview(Uint8List pdfBytes, String fileName, String text) {
+  void _openPdfPreview(
+      Uint8List pdfBytes, String fileName, String text, String? link) {
     Navigator.of(context).pushNamed('/pdf_preview', arguments: {
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
+      'link': link,
     });
   }
 
@@ -948,7 +950,7 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
 
     try {
       final pdfBytes = await pdf.save();
-      await uploadReportPdf(pdfBytes, fileName, token);
+      final link = await uploadReportPdf(pdfBytes, fileName, token);
 
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء التقرير بنجاح.', isError: false);
@@ -956,7 +958,8 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
       _openPdfPreview(
           pdfBytes,
           fileName,
-          'يرجى الاطلاع على التقرير المرفق.');
+          'يرجى الاطلاع على التقرير المرفق.',
+          link);
     } catch (e) {
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(

--- a/lib/pages/admin/admin_evaluations_page.dart
+++ b/lib/pages/admin/admin_evaluations_page.dart
@@ -1401,7 +1401,7 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
 
     try {
       final bytes = await pdf.save();
-      await uploadReportPdf(bytes, fileName, token);
+      final link = await uploadReportPdf(bytes, fileName, token);
 
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء التقرير بنجاح.', isError: false);
@@ -1414,12 +1414,16 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
           ..click();
         html.Url.revokeObjectUrl(url);
       } else {
-        final dir = await getTemporaryDirectory();
-        final path = '${dir.path}/$fileName';
-        final file = File(path);
-        await file.writeAsBytes(bytes);
-        await Share.shareXFiles(
-            [XFile(path)], text: 'تقرير تقييم ${evaluation.engineerName}');
+        if (link != null) {
+          await Share.share(link);
+        } else {
+          final dir = await getTemporaryDirectory();
+          final path = '${dir.path}/$fileName';
+          final file = File(path);
+          await file.writeAsBytes(bytes);
+          await Share.shareXFiles(
+              [XFile(path)], text: 'تقرير تقييم ${evaluation.engineerName}');
+        }
       }
     } catch (e) {
       _hideLoadingDialog(context);
@@ -1427,5 +1431,4 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
           context, 'فشل إنشاء أو مشاركة التقرير: $e', isError: true);
     }
   }
-
 }

--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1106,11 +1106,13 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
     }
   }
 
-  void _openPdfPreview(Uint8List pdfBytes, String fileName, String text) {
+  void _openPdfPreview(
+      Uint8List pdfBytes, String fileName, String text, String? link) {
     Navigator.of(context).pushNamed('/pdf_preview', arguments: {
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
+      'link': link,
     });
   }
 
@@ -1215,7 +1217,7 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
 
     try {
       final pdfBytes = await pdf.save();
-      await uploadReportPdf(pdfBytes, fileName, token);
+      final link = await uploadReportPdf(pdfBytes, fileName, token);
 
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء المحضر بنجاح.', isError: false);
@@ -1223,12 +1225,12 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
       _openPdfPreview(
           pdfBytes,
           fileName,
-          'يرجى الاطلاع على المحضر المرفق.');
+          'يرجى الاطلاع على المحضر المرفق.',
+          link);
     } catch (e) {
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'فشل إنشاء أو مشاركة المحضر: $e',
           isError: true);
       print('Error generating meeting PDF: $e');
     }
-  }
-}
+  }}

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1901,7 +1901,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
     final progress = ProgressDialog.show(context, 'جاري تحميل البيانات...');
 
     try {
-      final pdfBytes = await PdfReportGenerator.generate(
+      final result = await PdfReportGenerator.generate(
         projectId: widget.projectId,
         projectSnapshot: _projectDataSnapshot,
         phases: predefinedPhasesStructure,
@@ -1916,9 +1916,10 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
       _showFeedbackSnackBar(context, 'تم إنشاء التقرير بنجاح.', isError: false);
 
       _openPdfPreview(
-        pdfBytes,
+        result.bytes,
         fileName,
         'يرجى الإطلاع على $headerText للمشروع.',
+        result.downloadUrl,
       );
     } catch (e) {
       await ProgressDialog.hide(context);
@@ -2027,11 +2028,13 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
     }
   }
 
-  void _openPdfPreview(Uint8List pdfBytes, String fileName, String text) {
+  void _openPdfPreview(
+      Uint8List pdfBytes, String fileName, String text, String? link) {
     Navigator.of(context).pushNamed('/pdf_preview', arguments: {
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
+      'link': link,
       'phone': _clientPhone,
     });
   }

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1154,11 +1154,13 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
     }
   }
 
-  void _openPdfPreview(Uint8List pdfBytes, String fileName, String text) {
+  void _openPdfPreview(
+      Uint8List pdfBytes, String fileName, String text, String? link) {
     Navigator.of(context).pushNamed('/pdf_preview', arguments: {
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
+      'link': link,
     });
   }
 
@@ -1257,7 +1259,7 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
 
     try {
       final pdfBytes = await pdf.save();
-      await uploadReportPdf(pdfBytes, fileName, token);
+      final link = await uploadReportPdf(pdfBytes, fileName, token);
 
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, 'تم إنشاء المحضر بنجاح.', isError: false);
@@ -1266,6 +1268,7 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
         pdfBytes,
         fileName,
         'يرجى الاطلاع على المحضر المرفق.',
+        link,
       );
     } catch (e) {
       _hideLoadingDialog(context);
@@ -1274,5 +1277,4 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
       // ignore: avoid_print
       print('Error generating meeting PDF: $e');
     }
-  }
-}
+  }}

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -976,7 +976,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
 
     final fileName = 'daily_report_${DateFormat('yyyyMMdd_HHmmss').format(now)}.pdf';
     try {
-      final pdfBytes = await PdfReportGenerator.generate(
+      final result = await PdfReportGenerator.generate(
         projectId: widget.projectId,
         projectSnapshot: _projectDataSnapshot,
         phases: predefinedPhasesStructure,
@@ -990,9 +990,10 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       await ProgressDialog.hide(context);
       _showFeedbackSnackBar(context, getLocalizedText('تم إنشاء التقرير بنجاح.', 'Report generated successfully.'), isError: false);
       _openPdfPreview(
-        pdfBytes,
+        result.bytes,
         fileName,
         getLocalizedText('يرجى الإطلاع على التقرير للمشروع.', 'Please review the project report.'),
+        result.downloadUrl,
       );
     } catch (e) {
       await ProgressDialog.hide(context);
@@ -3838,7 +3839,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
 
     try {
       final pdfBytes = await pdf.save();
-      await uploadReportPdf(pdfBytes, fileName, token);
+      final link = await uploadReportPdf(pdfBytes, fileName, token);
 
       _hideLoadingDialog(context);
       _showFeedbackSnackBar(context, "تم إنشاء التقرير بنجاح.", isError: false);
@@ -3846,7 +3847,8 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       _openPdfPreview(
         pdfBytes,
         fileName,
-        'الرجاء الإطلاع على تقرير ${isTestSection ? "الاختبار" : "المرحلة"}: $name لمشروع $projectName.'
+        'الرجاء الإطلاع على تقرير ${isTestSection ? "الاختبار" : "المرحلة"}: $name لمشروع $projectName.',
+        link,
       );
 
     } catch (e) {
@@ -3878,11 +3880,13 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
     }
   }
 
-  void _openPdfPreview(Uint8List pdfBytes, String fileName, String text) {
+  void _openPdfPreview(
+      Uint8List pdfBytes, String fileName, String text, String? link) {
     Navigator.of(context).pushNamed('/pdf_preview', arguments: {
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
+      'link': link,
       'phone': _clientPhone,
     });
   }

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -27,6 +27,12 @@ import 'pdf_image_cache.dart';
 
 import 'report_storage.dart';
 
+class PdfReportResult {
+  final Uint8List bytes;
+  final String? downloadUrl;
+  PdfReportResult({required this.bytes, this.downloadUrl});
+}
+
 
 class PdfReportGenerator {
 
@@ -128,7 +134,7 @@ class PdfReportGenerator {
     return fetched;
   }
 
-  static Future<Uint8List> generate({
+  static Future<PdfReportResult> generate({
 
     required String projectId,
 
@@ -647,9 +653,9 @@ class PdfReportGenerator {
     final pdfBytes = await pdf.save();
     PdfImageCache.clear();
     onProgress?.call(1.0);
-    await uploadReportPdf(pdfBytes, fileName, token);
+    final url = await uploadReportPdf(pdfBytes, fileName, token);
 
-    return pdfBytes;
+    return PdfReportResult(bytes: pdfBytes, downloadUrl: url);
 
   }
 

--- a/lib/utils/report_storage.dart
+++ b/lib/utils/report_storage.dart
@@ -91,6 +91,6 @@ String buildReportDownloadUrl(String fileName, String token) {
 }
 
 // Upload the PDF using [ReportStorage] ignoring the token on the client side
-Future<void> uploadReportPdf(Uint8List bytes, String fileName, String token) async {
-  await ReportStorage.uploadReportPdf(bytes, fileName);
-}
+Future<String?> uploadReportPdf(
+    Uint8List bytes, String fileName, String token) async {
+  return await ReportStorage.uploadReportPdf(bytes, fileName);}


### PR DESCRIPTION
## Summary
- return uploaded PDF URL from `uploadReportPdf`
- return PDF bytes and link from `PdfReportGenerator.generate`
- pass the download link to PDF preview screens
- allow sharing report links in PDF preview
- adjust admin and engineer pages to use the new link-based flow

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e33fa5c88832abb5f42602dfd45a6