### PR TITLE
Implement isolate-based PDF report generation

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1901,15 +1901,14 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
     final progress = ProgressDialog.show(context, 'جاري تحميل البيانات...');
 
     try {
-      final result = await PdfReportGenerator.generate(
+      final result = await PdfReportGenerator.generateWithIsolate(
         projectId: widget.projectId,
-        projectSnapshot: _projectDataSnapshot,
+        projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
         phases: predefinedPhasesStructure,
         testsStructure: finalCommissioningTests,
         generatedBy: _currentAdminName,
         start: start,
         end: end,
-        onProgress: (p) => progress.value = p,
       );
 
       await ProgressDialog.hide(context);

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -976,15 +976,14 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
 
     final fileName = 'daily_report_${DateFormat('yyyyMMdd_HHmmss').format(now)}.pdf';
     try {
-      final result = await PdfReportGenerator.generate(
+      final result = await PdfReportGenerator.generateWithIsolate(
         projectId: widget.projectId,
-        projectSnapshot: _projectDataSnapshot,
+        projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
         phases: predefinedPhasesStructure,
         testsStructure: finalCommissioningTests,
         generatedBy: _currentEngineerName,
         start: start,
         end: end,
-        onProgress: (p) => progress.value = p,
       );
 
       await ProgressDialog.hide(context);


### PR DESCRIPTION
## Summary
- enable concurrent PDF generation by using `compute`
- pass project data maps instead of snapshots to PDF generator
- call the new isolate generator from admin and engineer pages

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f6397aec8832a96c26be8c52ecbcc