### PR TITLE
Fix ByteData usage for font

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -669,7 +669,7 @@ class PdfReportGenerator {
     DateTime? end,
   }) async {
     final fontData =
-        (await rootBundle.load('assets/fonts/Tajawal-Medium.ttf')).buffer;
+        await rootBundle.load('assets/fonts/Tajawal-Medium.ttf');
     _arabicFont = pw.Font.ttf(fontData);
 
     // Running the generation directly on the main isolate avoids issues with


### PR DESCRIPTION
## Summary
- fix `generateWithIsolate` font loading to use `ByteData`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f6d8d27f8832aafd58224b911aeb4