### PR TITLE
Reduce PDF generator memory usage

### DIFF
--- a/lib/utils/pdf_image_cache.dart
+++ b/lib/utils/pdf_image_cache.dart
@@ -11,7 +11,9 @@ class PdfImageCache {
   static final LinkedHashMap<String, pw.MemoryImage> _cache = LinkedHashMap();
   // Maximum number of images to keep in memory at any time. Reducing the
   // cache size lowers peak memory usage when a report contains many photos.
-  static const int _maxEntries = 150;
+  // Fewer cached images further limit memory usage when generating
+  // very large reports with hundreds of pictures.
+  static const int _maxEntries = 50;
 
   static pw.MemoryImage? get(String url) {
     final img = _cache.remove(url);

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -40,7 +40,10 @@ class PdfReportGenerator {
   // Limit the dimensions of embedded images so large photos do not cause
   // out-of-memory errors when generating huge reports. Lowering the limit
   // further reduces peak memory usage when many images are embedded.
-  static const int _maxImageDimension = 512;
+  // Lowering the dimension reduces the memory consumed when many
+  // pictures are included in a single report. 256 keeps reasonable
+  // clarity while cutting peak usage roughly in half.
+  static const int _maxImageDimension = 256;
   // JPEG quality used when encoding resized images.
   static const int _jpgQuality = 75;
 
@@ -94,7 +97,8 @@ class PdfReportGenerator {
   static Future<Map<String, pw.MemoryImage>> _fetchImagesForUrls(
       List<String> urls, {
       void Function(double progress)? onProgress,
-      int concurrency = 5,
+      // Reduce concurrent downloads to lower simultaneous memory pressure.
+      int concurrency = 3,
     }) async {
     final Map<String, pw.MemoryImage> fetched = {};
     final uniqueUrls = urls.toSet().toList();

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -9,8 +9,8 @@ void main() {
     final bytes = Uint8List.fromList(img.encodeJpg(image));
     final resized = await PdfReportGenerator.resizeImageForTest(bytes);
     final decoded = img.decodeImage(resized)!;
-    // Images should be resized to at most 512 pixels on the longest side
-    expect(decoded.width <= 512, isTrue);
-    expect(decoded.height <= 512, isTrue);
+    // Images should be resized to at most 256 pixels on the longest side
+    expect(decoded.width <= 256, isTrue);
+    expect(decoded.height <= 256, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- lower embedded image size to shrink memory requirements
- reduce concurrent image fetches
- shrink PDF image cache
- update test for new image dimensions

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f6eefac00832abc3b804a119d694d