### PR TITLE
Improve PDF image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A comprehensive system for managing projects, engineers, clients, and employees,
     * Define weekly and official holidays (including programmed Saudi official holidays).
 * **PDF Support**:
     * Generate and export detailed PDF reports for projects, attendance records, and meeting minutes.
+    * Images in generated reports are fetched and resized up to 1024px to handle large photos without running out of memory.
 
 ## Technologies Used
 

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -41,11 +41,11 @@ class PdfReportGenerator {
   // out-of-memory errors when generating huge reports. Lowering the limit
   // further reduces peak memory usage when many images are embedded.
   // Lowering the dimension reduces the memory consumed when many
-  // pictures are included in a single report. 256 keeps reasonable
-  // clarity while cutting peak usage roughly in half.
-  static const int _maxImageDimension = 256;
+  // pictures are included in a single report. Using 1024 keeps better
+  // clarity for large photos while still bounding memory usage.
+  static const int _maxImageDimension = 1024;
   // JPEG quality used when encoding resized images.
-  static const int _jpgQuality = 75;
+  static const int _jpgQuality = 85;
 
 
   static Future<void> _loadArabicFont() async {
@@ -113,7 +113,7 @@ class PdfReportGenerator {
         try {
           final response = await http
               .get(Uri.parse(url))
-              .timeout(const Duration(seconds: 60));
+              .timeout(const Duration(seconds: 120));
           final contentType = response.headers['content-type'] ?? '';
           if (response.statusCode == 200 && contentType.startsWith('image/')) {
             final resizedBytes =

--- a/lib/utils/report_storage.dart
+++ b/lib/utils/report_storage.dart
@@ -26,7 +26,7 @@ class ReportStorage {
 
       var response = await request
           .send()
-          .timeout(const Duration(seconds: 60));
+          .timeout(const Duration(minutes: 2));
 
       if (response.statusCode == 200) {
         final responseBody = await response.stream.bytesToString();
@@ -60,7 +60,7 @@ class ReportStorage {
     try {
       final response = await http
           .get(Uri.parse(url))
-          .timeout(const Duration(seconds: 60));
+          .timeout(const Duration(minutes: 2));
       if (response.statusCode == 200) {
         return response.bodyBytes;
       } else {


### PR DESCRIPTION
## Summary
- raise PDF image resize limit to 1024px for better quality
- increase JPEG quality used when embedding images
- extend HTTP timeouts for image fetching and report upload/download
- document the new PDF image support

## Testing
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f71d13a1c832abb7ac67612ac6464