### PR TITLE
Add low memory mode for PDF generation

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1901,15 +1901,30 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
     final progress = ProgressDialog.show(context, 'جاري تحميل البيانات...');
 
     try {
-      final result = await PdfReportGenerator.generateWithIsolate(
-        projectId: widget.projectId,
-        projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
-        phases: predefinedPhasesStructure,
-        testsStructure: finalCommissioningTests,
-        generatedBy: _currentAdminName,
-        start: start,
-        end: end,
-      );
+      PdfReportResult result;
+      try {
+        result = await PdfReportGenerator.generateWithIsolate(
+          projectId: widget.projectId,
+          projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
+          phases: predefinedPhasesStructure,
+          testsStructure: finalCommissioningTests,
+          generatedBy: _currentAdminName,
+          start: start,
+          end: end,
+        );
+      } catch (e) {
+        // Retry with low-memory settings if initial attempt fails.
+        result = await PdfReportGenerator.generateWithIsolate(
+          projectId: widget.projectId,
+          projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
+          phases: predefinedPhasesStructure,
+          testsStructure: finalCommissioningTests,
+          generatedBy: _currentAdminName,
+          start: start,
+          end: end,
+          lowMemory: true,
+        );
+      }
 
       await ProgressDialog.hide(context);
       _showFeedbackSnackBar(context, 'تم إنشاء التقرير بنجاح.', isError: false);

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -976,15 +976,30 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
 
     final fileName = 'daily_report_${DateFormat('yyyyMMdd_HHmmss').format(now)}.pdf';
     try {
-      final result = await PdfReportGenerator.generateWithIsolate(
-        projectId: widget.projectId,
-        projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
-        phases: predefinedPhasesStructure,
-        testsStructure: finalCommissioningTests,
-        generatedBy: _currentEngineerName,
-        start: start,
-        end: end,
-      );
+      PdfReportResult result;
+      try {
+        result = await PdfReportGenerator.generateWithIsolate(
+          projectId: widget.projectId,
+          projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
+          phases: predefinedPhasesStructure,
+          testsStructure: finalCommissioningTests,
+          generatedBy: _currentEngineerName,
+          start: start,
+          end: end,
+        );
+      } catch (e) {
+        // Retry with low-memory settings if initial attempt fails.
+        result = await PdfReportGenerator.generateWithIsolate(
+          projectId: widget.projectId,
+          projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
+          phases: predefinedPhasesStructure,
+          testsStructure: finalCommissioningTests,
+          generatedBy: _currentEngineerName,
+          start: start,
+          end: end,
+          lowMemory: true,
+        );
+      }
 
       await ProgressDialog.hide(context);
       _showFeedbackSnackBar(context, getLocalizedText('تم إنشاء التقرير بنجاح.', 'Report generated successfully.'), isError: false);

--- a/test/pdf_report_generator_test.dart
+++ b/test/pdf_report_generator_test.dart
@@ -7,7 +7,8 @@ void main() {
   test('resizeImageForTest downscales large images', () async {
     final image = img.Image(width: 2000, height: 2000); // Solid image
     final bytes = Uint8List.fromList(img.encodeJpg(image));
-    final resized = await PdfReportGenerator.resizeImageForTest(bytes);
+    final resized =
+        await PdfReportGenerator.resizeImageForTest(bytes, maxDimension: 256);
     final decoded = img.decodeImage(resized)!;
     // Images should be resized to at most 256 pixels on the longest side
     expect(decoded.width <= 256, isTrue);


### PR DESCRIPTION
## Summary
- add configurable low-memory settings to `PdfReportGenerator`
- retry with low-memory mode when PDF generation fails
- expose resize helper for tests with adjustable size

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f73e30c74832a8b2a8ff2d20bbe91