### PR TITLE
Fix lowMemory parameter

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -164,6 +164,7 @@ class PdfReportGenerator {
     DateTime? end,
     void Function(double progress)? onProgress,
 
+    bool lowMemory = false,
   }) async {
     // Ensure the cache does not retain images from previous reports
     PdfImageCache.clear();


### PR DESCRIPTION
## Summary
- add missing `lowMemory` named parameter to `PdfReportGenerator.generate`

## Testing
- `git show -n 1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686f759a5c38832a89e120152cbe9f94