### PR TITLE
Improve PDF generation memory management

### DIFF
--- a/lib/utils/pdf_image_cache.dart
+++ b/lib/utils/pdf_image_cache.dart
@@ -13,7 +13,7 @@ class PdfImageCache {
   // cache size lowers peak memory usage when a report contains many photos.
   // Fewer cached images further limit memory usage when generating
   // very large reports with hundreds of pictures.
-  static const int _maxEntries = 50;
+  static const int _maxEntries = 20;
 
   static pw.MemoryImage? get(String url) {
     final img = _cache.remove(url);

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -46,8 +46,8 @@ class PdfReportGenerator {
   static const int _maxImageDimension = 1024;
   static const int _jpgQuality = 85;
   // More aggressive settings for devices with limited memory.
-  static const int _lowMemImageDimension = 512;
-  static const int _lowMemJpgQuality = 70;
+  static const int _lowMemImageDimension = 256;
+  static const int _lowMemJpgQuality = 60;
 
 
   static Future<void> _loadArabicFont() async {
@@ -169,6 +169,7 @@ class PdfReportGenerator {
     // Ensure the cache does not retain images from previous reports
     PdfImageCache.clear();
     onProgress?.call(0.0);
+    try {
 
     final int imgDim =
         lowMemory ? _lowMemImageDimension : _maxImageDimension;
@@ -673,11 +674,13 @@ class PdfReportGenerator {
 
 
     final pdfBytes = await pdf.save();
-    PdfImageCache.clear();
     onProgress?.call(1.0);
     final url = await uploadReportPdf(pdfBytes, fileName, token);
 
     return PdfReportResult(bytes: pdfBytes, downloadUrl: url);
+    } finally {
+      PdfImageCache.clear();
+    }
 
   }
 
@@ -1667,6 +1670,7 @@ class PdfReportGenerator {
   }) async {
     PdfImageCache.clear();
     onProgress?.call(0.0);
+    try {
     final int imgDim =
         lowMemory ? _lowMemImageDimension : _maxImageDimension;
     final int imgQuality = lowMemory ? _lowMemJpgQuality : _jpgQuality;
@@ -1876,10 +1880,12 @@ class PdfReportGenerator {
     );
 
     final bytes = await pdf.save();
-    PdfImageCache.clear();
     onProgress?.call(1.0);
     await uploadReportPdf(bytes, fileName, token);
     return bytes;
+    } finally {
+      PdfImageCache.clear();
+    }
   }
 
   static pw.Widget _buildSimpleEntriesTable(


### PR DESCRIPTION
## Summary
- lower the maximum image cache entries
- add more aggressive low memory settings
- ensure cached images are cleared even when generation fails

## Testing
- `dart format lib/utils/pdf_report_generator.dart lib/utils/pdf_image_cache.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7b0de6c8832aa6bc09755a8ef924