### PR TITLE
Handle PDF OOM with simple fallback

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1938,9 +1938,30 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         result.downloadUrl,
       );
     } catch (e) {
-      await ProgressDialog.hide(context);
-      _showFeedbackSnackBar(context, 'فشل إنشاء أو مشاركة التقرير: $e', isError: true);
-      print('Error generating daily report PDF: $e');
+      try {
+        progress.value = 0.0;
+        final bytes = await PdfReportGenerator.generateSimpleTables(
+          projectId: widget.projectId,
+          phases: predefinedPhasesStructure,
+          testsStructure: finalCommissioningTests,
+          start: start,
+          end: end,
+          onProgress: (p) => progress.value = p,
+          lowMemory: true,
+        );
+        await ProgressDialog.hide(context);
+        _showFeedbackSnackBar(context, 'تم إنشاء تقرير مبسط بسبب نقص الذاكرة.', isError: false);
+        _openPdfPreview(
+          bytes,
+          fileName,
+          'يرجى الإطلاع على $headerText للمشروع.',
+          null,
+        );
+      } catch (e2) {
+        await ProgressDialog.hide(context);
+        _showFeedbackSnackBar(context, 'فشل إنشاء أو مشاركة التقرير: $e2', isError: true);
+        print('Error generating daily report PDF: $e2');
+      }
     }
   }
 

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -1013,9 +1013,34 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         result.downloadUrl,
       );
     } catch (e) {
-      await ProgressDialog.hide(context);
-      _showFeedbackSnackBar(context, getLocalizedText('فشل إنشاء أو مشاركة التقرير: $e', 'Failed to generate or share report: $e'), isError: true);
-      print('Error generating daily report PDF: $e');
+      try {
+        progress.value = 0.0;
+        final bytes = await PdfReportGenerator.generateSimpleTables(
+          projectId: widget.projectId,
+          phases: predefinedPhasesStructure,
+          testsStructure: finalCommissioningTests,
+          start: start,
+          end: end,
+          onProgress: (p) => progress.value = p,
+          lowMemory: true,
+        );
+        await ProgressDialog.hide(context);
+        _showFeedbackSnackBar(
+          context,
+          getLocalizedText('تم إنشاء تقرير مبسط بسبب نقص الذاكرة.', 'Generated simplified report due to low memory.'),
+          isError: false,
+        );
+        _openPdfPreview(
+          bytes,
+          fileName,
+          getLocalizedText('يرجى الإطلاع على التقرير للمشروع.', 'Please review the project report.'),
+          null,
+        );
+      } catch (e2) {
+        await ProgressDialog.hide(context);
+        _showFeedbackSnackBar(context, getLocalizedText('فشل إنشاء أو مشاركة التقرير: $e2', 'Failed to generate or share report: $e2'), isError: true);
+        print('Error generating daily report PDF: $e2');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- retry PDF generation with a simpler layout when low-memory attempts fail

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8044b18c832aa7870d0daba2e17c