### PR TITLE
Skip large images during PDF creation

### DIFF
--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1068,6 +1068,19 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
       }
 
       try {
+        // Protect against very large images which may trigger OOM errors.
+        try {
+          final head = await http
+              .head(Uri.parse(url))
+              .timeout(const Duration(seconds: 30));
+          final lenStr = head.headers['content-length'];
+          final len = lenStr != null ? int.tryParse(lenStr) : null;
+          if (len != null && len > PdfReportGenerator._maxImageFileSize) {
+            print('Skipping large image from URL $url: $len bytes');
+            return;
+          }
+        } catch (_) {}
+
         final response = await http
             .get(Uri.parse(url))
             .timeout(const Duration(seconds: 60));

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -2028,6 +2028,19 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
       }
 
       try {
+        // Skip huge images that could cause out-of-memory crashes.
+        try {
+          final head = await http
+              .head(Uri.parse(url))
+              .timeout(const Duration(seconds: 30));
+          final lenStr = head.headers['content-length'];
+          final len = lenStr != null ? int.tryParse(lenStr) : null;
+          if (len != null && len > PdfReportGenerator._maxImageFileSize) {
+            print('Skipping large image from URL $url: $len bytes');
+            return;
+          }
+        } catch (_) {}
+
         final response = await http
             .get(Uri.parse(url))
             .timeout(const Duration(seconds: 60));

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1114,6 +1114,20 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
       }
 
       try {
+        // Skip very large images to prevent memory issues when decoding.
+        try {
+          final head = await http
+              .head(Uri.parse(url))
+              .timeout(const Duration(seconds: 30));
+          final lenStr = head.headers['content-length'];
+          final len = lenStr != null ? int.tryParse(lenStr) : null;
+          if (len != null && len > PdfReportGenerator._maxImageFileSize) {
+            // ignore: avoid_print
+            print('Skipping large image from URL $url: $len bytes');
+            return;
+          }
+        } catch (_) {}
+
         final response = await http
             .get(Uri.parse(url))
             .timeout(const Duration(seconds: 60));

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -3385,6 +3385,19 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
       }
 
       try {
+        // Avoid downloading extremely large images that could exhaust memory.
+        try {
+          final head = await http
+              .head(Uri.parse(url))
+              .timeout(const Duration(seconds: 30));
+          final lenStr = head.headers['content-length'];
+          final len = lenStr != null ? int.tryParse(lenStr) : null;
+          if (len != null && len > PdfReportGenerator._maxImageFileSize) {
+            print('Skipping large image from URL $url: $len bytes');
+            return;
+          }
+        } catch (_) {}
+
         final response = await http
             .get(Uri.parse(url))
             .timeout(const Duration(seconds: 60));


### PR DESCRIPTION
## Summary
- prevent oversized images from causing OOM
- add a maximum image file size check when downloading images
- reuse the same check across all PDF generation helpers

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_686f8279b294832ab976c92ccb92fb8a