### PR TITLE
Fix reference to image file size limit

### DIFF
--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1075,7 +1075,7 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
               .timeout(const Duration(seconds: 30));
           final lenStr = head.headers['content-length'];
           final len = lenStr != null ? int.tryParse(lenStr) : null;
-          if (len != null && len > PdfReportGenerator._maxImageFileSize) {
+          if (len != null && len > PdfReportGenerator.maxImageFileSize) {
             print('Skipping large image from URL $url: $len bytes');
             return;
           }

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -2035,7 +2035,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
               .timeout(const Duration(seconds: 30));
           final lenStr = head.headers['content-length'];
           final len = lenStr != null ? int.tryParse(lenStr) : null;
-          if (len != null && len > PdfReportGenerator._maxImageFileSize) {
+          if (len != null && len > PdfReportGenerator.maxImageFileSize) {
             print('Skipping large image from URL $url: $len bytes');
             return;
           }

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1121,7 +1121,7 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
               .timeout(const Duration(seconds: 30));
           final lenStr = head.headers['content-length'];
           final len = lenStr != null ? int.tryParse(lenStr) : null;
-          if (len != null && len > PdfReportGenerator._maxImageFileSize) {
+          if (len != null && len > PdfReportGenerator.maxImageFileSize) {
             // ignore: avoid_print
             print('Skipping large image from URL $url: $len bytes');
             return;

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -3392,7 +3392,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
               .timeout(const Duration(seconds: 30));
           final lenStr = head.headers['content-length'];
           final len = lenStr != null ? int.tryParse(lenStr) : null;
-          if (len != null && len > PdfReportGenerator._maxImageFileSize) {
+          if (len != null && len > PdfReportGenerator.maxImageFileSize) {
             print('Skipping large image from URL $url: $len bytes');
             return;
           }

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -50,7 +50,8 @@ class PdfReportGenerator {
   static const int _lowMemJpgQuality = 60;
   // Skip downloading images that exceed this size in bytes to avoid
   // exhausting memory on devices with limited resources.
-  static const int _maxImageFileSize = 5 * 1024 * 1024; // 5 MB
+  // Made public so other libraries can reference this limit.
+  static const int maxImageFileSize = 5 * 1024 * 1024; // 5 MB
 
 
   static Future<void> _loadArabicFont() async {
@@ -131,7 +132,7 @@ class PdfReportGenerator {
                 .timeout(const Duration(seconds: 30));
             final lenStr = head.headers['content-length'];
             final len = lenStr != null ? int.tryParse(lenStr) : null;
-            if (len != null && len > _maxImageFileSize) {
+            if (len != null && len > maxImageFileSize) {
               // Skip oversized images
               print('Skipping large image from URL $url: $len bytes');
               return;


### PR DESCRIPTION
## Summary
- expose `maxImageFileSize` in `PdfReportGenerator`
- update all references in admin and engineer pages

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f840f1bf8832a9c487255475eb0b2