### PR TITLE
Use links instead of images in PDFs

### DIFF
--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1164,7 +1164,6 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
       imageUrls.add(data['imageUrl'] as String);
     }
 
-    final fetchedImages = await _fetchImagesForUrls(imageUrls);
 
     final pdf = pw.Document();
     final fileName =
@@ -1211,11 +1210,20 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
             widgets.add(pw.SizedBox(height: 10));
           }
           for (final url in imageUrls) {
-            final imgMem = fetchedImages[url];
-            if (imgMem != null) {
-              widgets.add(pw.Image(imgMem, width: 400, fit: pw.BoxFit.contain));
-              widgets.add(pw.SizedBox(height: 10));
-            }
+            widgets.add(
+              pw.UrlLink(
+                destination: url,
+                child: pw.Text(
+                  'عرض',
+                  style: pw.TextStyle(
+                    color: PdfColors.blue,
+                    decoration: pw.TextDecoration.underline,
+                  ),
+                  textDirection: pw.TextDirection.rtl,
+                ),
+              ),
+            );
+            widgets.add(pw.SizedBox(height: 10));
           }
           return widgets;
         },

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1213,7 +1213,6 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
       imageUrls.add(data['imageUrl'] as String);
     }
 
-    final fetchedImages = await _fetchImagesForUrls(imageUrls);
 
     final pdf = pw.Document();
     final fileName =
@@ -1254,11 +1253,20 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
             widgets.add(pw.SizedBox(height: 10));
           }
           for (final url in imageUrls) {
-            final imgMem = fetchedImages[url];
-            if (imgMem != null) {
-              widgets.add(pw.Image(imgMem, width: 400, fit: pw.BoxFit.contain));
-              widgets.add(pw.SizedBox(height: 10));
-            }
+            widgets.add(
+              pw.UrlLink(
+                destination: url,
+                child: pw.Text(
+                  'عرض',
+                  style: pw.TextStyle(
+                    color: PdfColors.blue,
+                    decoration: pw.TextDecoration.underline,
+                  ),
+                  textDirection: pw.TextDirection.rtl,
+                ),
+              ),
+            );
+            widgets.add(pw.SizedBox(height: 10));
           }
           return widgets;
         },

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -1131,48 +1131,26 @@ class PdfReportGenerator {
       List<String> urls,
       Map<String, pw.MemoryImage> fetchedImages,
       PdfColor borderColor) {
-    final availableImages =
-        urls.where((u) => fetchedImages.containsKey(u)).toList();
-    if (availableImages.isEmpty) return pw.SizedBox();
+    if (urls.isEmpty) return pw.SizedBox();
 
-    List<pw.Widget> rows = [];
-    for (int i = 0; i < availableImages.length; i += 3) {
-      final rowImages = availableImages.skip(i).take(3).toList();
-      rows.add(
-        pw.Container(
-          margin: const pw.EdgeInsets.only(bottom: 15),
-          child: pw.Row(
-            mainAxisAlignment: pw.MainAxisAlignment.spaceEvenly,
-            children: rowImages
-                .map((imageUrl) => pw.Container(
-                      width: 180,
-                      height: 210,
-                      decoration: pw.BoxDecoration(
-                        border: pw.Border.all(color: borderColor, width: 1.5),
-                        borderRadius: pw.BorderRadius.zero,
-                        boxShadow: [
-                          pw.BoxShadow(
-                            color: PdfColors.grey300,
-                            blurRadius: 2,
-                          ),
-                        ],
-                      ),
-                      child: pw.ClipRRect(
-                        horizontalRadius: 0,
-                        verticalRadius: 0,
-                        child: pw.Image(
-                          fetchedImages[imageUrl]!,
-                          fit: pw.BoxFit.cover,
-                        ),
-                      ),
-                    ))
-                .toList(),
-          ),
-        ),
-      );
-    }
-
-    return pw.Column(children: rows);
+    return pw.Wrap(
+      spacing: 10,
+      runSpacing: 10,
+      alignment: pw.WrapAlignment.end,
+      children: urls
+          .map((url) => pw.UrlLink(
+                destination: url,
+                child: pw.Text(
+                  'عرض',
+                  style: pw.TextStyle(
+                    color: PdfColors.blue,
+                    decoration: pw.TextDecoration.underline,
+                  ),
+                  textDirection: pw.TextDirection.rtl,
+                ),
+              ))
+          .toList(),
+    );
   }
 
 
@@ -1354,7 +1332,7 @@ class PdfReportGenerator {
           ),
 
           // Image Section
-          if (imgUrl != null && fetchedImages.containsKey(imgUrl)) ...[
+          if (imgUrl != null) ...[
             pw.SizedBox(height: 20),
             pw.Container(
               width: double.infinity,
@@ -1376,29 +1354,15 @@ class PdfReportGenerator {
               ),
             ),
             pw.SizedBox(height: 10),
-
-            pw.Center(
-              child: pw.Container(
-                width: 230,
-                height: 280,
-                decoration: pw.BoxDecoration(
-                  border: pw.Border.all(color: borderColor, width: 1.5),
-                  borderRadius: pw.BorderRadius.zero,
-                  boxShadow: [
-                    pw.BoxShadow(
-                      color: PdfColors.grey300,
-                      blurRadius: 2,
-                    ),
-                  ],
+            pw.UrlLink(
+              destination: imgUrl,
+              child: pw.Text(
+                'عرض',
+                style: pw.TextStyle(
+                  color: PdfColors.blue,
+                  decoration: pw.TextDecoration.underline,
                 ),
-                child: pw.ClipRRect(
-                  horizontalRadius: 0,
-                  verticalRadius: 0,
-                  child: pw.Image(
-                    fetchedImages[imgUrl]!,
-                    fit: pw.BoxFit.cover,
-                  ),
-                ),
+                textDirection: pw.TextDirection.rtl,
               ),
             ),
           ],
@@ -1946,16 +1910,19 @@ class PdfReportGenerator {
             (item['imageUrls'] as List?)?.map((it) => it.toString()).toList() ?? [];
         final imgWidgets = <pw.Widget>[];
         for (final url in imgs) {
-          final img = images[url];
-          if (img != null) {
-            imgWidgets.add(
-              pw.Container(
-                margin: const pw.EdgeInsets.all(2),
-                child: pw.Image(img,
-                    width: 120, height: 120, fit: pw.BoxFit.cover),
+          imgWidgets.add(
+            pw.UrlLink(
+              destination: url,
+              child: pw.Text(
+                'عرض',
+                style: pw.TextStyle(
+                  color: PdfColors.blue,
+                  decoration: pw.TextDecoration.underline,
+                ),
+                textDirection: pw.TextDirection.rtl,
               ),
-            );
-          }
+            ),
+          );
         }
 
         widgets.add(
@@ -2062,14 +2029,19 @@ class PdfReportGenerator {
       for (final item in items) {
         final note = item['note']?.toString() ?? '';
         final url = item['imageUrl'] as String?;
-        final img = url != null ? images[url] : null;
         final imgWidgets = <pw.Widget>[];
-        if (img != null) {
+        if (url != null) {
           imgWidgets.add(
-            pw.Container(
-              margin: const pw.EdgeInsets.all(2),
-              child:
-                  pw.Image(img, width: 120, height: 120, fit: pw.BoxFit.cover),
+            pw.UrlLink(
+              destination: url,
+              child: pw.Text(
+                'عرض',
+                style: pw.TextStyle(
+                  color: PdfColors.blue,
+                  decoration: pw.TextDecoration.underline,
+                ),
+                textDirection: pw.TextDirection.rtl,
+              ),
             ),
           );
         }


### PR DESCRIPTION
## Summary
- render images as hyperlinks when building PDFs
- drop image fetching for faster generation

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f87072564832a81fec29c3ccf6e8e