### PR TITLE
Fix RTL alignment for image attachments

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -2184,9 +2184,12 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                const Text('صور قبل:', style: TextStyle(fontWeight: FontWeight.bold)),
+                                const Text('صور قبل:',
+                                    style: TextStyle(fontWeight: FontWeight.bold),
+                                    textAlign: TextAlign.right),
                                 const SizedBox(height: 4),
                                 Wrap(
+                                  textDirection: ui.TextDirection.rtl,
                                   spacing: AppConstants.paddingSmall / 2,
                                   runSpacing: AppConstants.paddingSmall / 2,
                                   children: beforeUrls.map((url) {
@@ -2209,9 +2212,12 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                const Text('صور بعد:', style: TextStyle(fontWeight: FontWeight.bold)),
+                                const Text('صور بعد:',
+                                    style: TextStyle(fontWeight: FontWeight.bold),
+                                    textAlign: TextAlign.right),
                                 const SizedBox(height: 4),
                                 Wrap(
+                                  textDirection: ui.TextDirection.rtl,
                                   spacing: AppConstants.paddingSmall / 2,
                                   runSpacing: AppConstants.paddingSmall / 2,
                                   children: afterUrls.map((url) {
@@ -2232,6 +2238,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
                           Padding(
                             padding: EdgeInsets.only(bottom: note.isNotEmpty ? AppConstants.paddingSmall : 0),
                             child: Wrap(
+                              textDirection: ui.TextDirection.rtl,
                               spacing: AppConstants.paddingSmall / 1.5,
                               runSpacing: AppConstants.paddingSmall / 1.5,
                               children: imageUrlsToDisplay.map((url) {

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -3071,9 +3071,12 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                const Text('صور قبل:', style: TextStyle(fontWeight: FontWeight.bold)),
+                                const Text('صور قبل:',
+                                    style: TextStyle(fontWeight: FontWeight.bold),
+                                    textAlign: TextAlign.right),
                                 const SizedBox(height: 4),
                                 Wrap(
+                                  textDirection: ui.TextDirection.rtl,
                                   spacing: AppConstants.paddingSmall / 2,
                                   runSpacing: AppConstants.paddingSmall / 2,
                                   children: beforeUrls.map((url) {
@@ -3096,9 +3099,12 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                const Text('صور بعد:', style: TextStyle(fontWeight: FontWeight.bold)),
+                                const Text('صور بعد:',
+                                    style: TextStyle(fontWeight: FontWeight.bold),
+                                    textAlign: TextAlign.right),
                                 const SizedBox(height: 4),
                                 Wrap(
+                                  textDirection: ui.TextDirection.rtl,
                                   spacing: AppConstants.paddingSmall / 2,
                                   runSpacing: AppConstants.paddingSmall / 2,
                                   children: afterUrls.map((url) {
@@ -3121,9 +3127,12 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                const Text('صور إضافية:', style: TextStyle(fontWeight: FontWeight.bold)),
+                                const Text('صور إضافية:',
+                                    style: TextStyle(fontWeight: FontWeight.bold),
+                                    textAlign: TextAlign.right),
                                 const SizedBox(height: 4),
                                 Wrap(
+                                  textDirection: ui.TextDirection.rtl,
                                   spacing: AppConstants.paddingSmall / 2,
                                   runSpacing: AppConstants.paddingSmall / 2,
                                   children: imageUrls.map((url) {

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -1148,6 +1148,7 @@ class PdfReportGenerator {
       spacing: 10,
       runSpacing: 10,
       alignment: pw.WrapAlignment.end,
+      textDirection: pw.TextDirection.rtl,
       children: [
         for (int i = 0; i < urls.length; i++)
           pw.UrlLink(


### PR DESCRIPTION
## Summary
- align attachment section headings and image grids from right-to-left
- ensure PDF image grids also use RTL text direction

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8b64b310832ab02bca204eaa8bb8