### PR TITLE
Handle attachments based on type

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1608,7 +1608,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
                     leading: const Icon(Icons.attach_file_outlined),
                     title: Text(fileName),
                     subtitle: Text('بواسطة: $uploader'),
-                    onTap: fileUrl != null ? () => launchUrl(Uri.parse(fileUrl)) : null,
+                    onTap: fileUrl != null ? () => _handleFileTap(fileUrl) : null,
                   );
                 },
               );
@@ -2342,6 +2342,16 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         actionsAlignment: MainAxisAlignment.center,
       ),
     );
+  }
+
+  void _handleFileTap(String url) {
+    final lower = url.toLowerCase();
+    const exts = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'];
+    if (exts.any((e) => lower.endsWith(e))) {
+      _viewImageDialog(url);
+    } else {
+      launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    }
   }
 
   void _showSingleImageSourceActionSheet(BuildContext context, Function(XFile?) onImageSelected) {

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -617,7 +617,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
                     leading: const Icon(Icons.attach_file_outlined),
                     title: Text(fileName),
                     subtitle: Text('بواسطة: $uploader'),
-                    onTap: fileUrl != null ? () => launchUrl(Uri.parse(fileUrl)) : null,
+                    onTap: fileUrl != null ? () => _handleFileTap(fileUrl) : null,
                   );
                 },
               );
@@ -3220,6 +3220,16 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         actionsAlignment: MainAxisAlignment.center,
       ),
     );
+  }
+
+  void _handleFileTap(String url) {
+    final lower = url.toLowerCase();
+    const exts = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'];
+    if (exts.any((e) => lower.endsWith(e))) {
+      _viewImageDialog(url);
+    } else {
+      launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    }
   }
 
   // --- Helper function to fetch entries for PDF ---


### PR DESCRIPTION
## Summary
- open file attachments using image dialog if they're images
- otherwise open the file URL externally

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa25e5dc8832a8ad347b247b35359