### PR TITLE
Enable image preview from PDF screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -179,6 +179,7 @@ class MyApp extends StatelessWidget {
                 shareText: args['text'] as String,
                 clientPhone: args['phone'] as String?,
                 shareLink: args['link'] as String?,
+                imageUrl: args['image'] as String?,
               );
             }
             return const Scaffold(body: Center(child: Text('لا يمكن عرض الملف')));

--- a/lib/pages/admin/admin_attendance_report_page.dart
+++ b/lib/pages/admin/admin_attendance_report_page.dart
@@ -815,12 +815,14 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
   }
 
   void _openPdfPreview(
-      Uint8List pdfBytes, String fileName, String text, String? link) {
+      Uint8List pdfBytes, String fileName, String text, String? link,
+      {String? imageUrl}) {
     Navigator.of(context).pushNamed('/pdf_preview', arguments: {
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
       'link': link,
+      'image': imageUrl,
     });
   }
 

--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1120,12 +1120,14 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
   }
 
   void _openPdfPreview(
-      Uint8List pdfBytes, String fileName, String text, String? link) {
+      Uint8List pdfBytes, String fileName, String text, String? link,
+      {String? imageUrl}) {
     Navigator.of(context).pushNamed('/pdf_preview', arguments: {
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
       'link': link,
+      'image': imageUrl,
     });
   }
 

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -2079,13 +2079,15 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
   }
 
   void _openPdfPreview(
-      Uint8List pdfBytes, String fileName, String text, String? link) {
+      Uint8List pdfBytes, String fileName, String text, String? link,
+      {String? imageUrl}) {
     Navigator.of(context).pushNamed('/pdf_preview', arguments: {
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
       'link': link,
       'phone': _clientPhone,
+      'image': imageUrl,
     });
   }
 

--- a/lib/pages/common/pdf_preview_screen.dart
+++ b/lib/pages/common/pdf_preview_screen.dart
@@ -19,6 +19,7 @@ class PdfPreviewScreen extends StatelessWidget {
   final String shareText;
   final String? clientPhone; // This already exists
   final String? shareLink;
+  final String? imageUrl;
 
   const PdfPreviewScreen({
     Key? key,
@@ -27,6 +28,7 @@ class PdfPreviewScreen extends StatelessWidget {
     required this.shareText,
     this.clientPhone, // This already exists
     this.shareLink,
+    this.imageUrl,
   }) : super(key: key);
 
   Future<void> _sharePdf(BuildContext context) async {
@@ -72,6 +74,44 @@ class PdfPreviewScreen extends StatelessWidget {
     );
   }
 
+  Future<void> _viewImageDialog(BuildContext context, String imageUrl) async {
+    await showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: Colors.transparent,
+        contentPadding: EdgeInsets.zero,
+        insetPadding: const EdgeInsets.all(10),
+        content: InteractiveViewer(
+          panEnabled: true,
+          boundaryMargin: const EdgeInsets.all(20),
+          minScale: 0.5,
+          maxScale: 4,
+          child: Image.network(
+            imageUrl,
+            fit: BoxFit.contain,
+            loadingBuilder: (ctx, child, progress) => progress == null
+                ? child
+                : const Center(
+                    child: CircularProgressIndicator(
+                        color: AppConstants.primaryColor)),
+            errorBuilder: (ctx, err, st) => const Center(
+                child: Icon(Icons.error_outline,
+                    color: AppConstants.errorColor, size: 50)),
+          ),
+        ),
+        actions: [
+          TextButton(
+            style:
+                TextButton.styleFrom(backgroundColor: Colors.black.withOpacity(0.5)),
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('إغلاق', style: TextStyle(color: Colors.white)),
+          )
+        ],
+        actionsAlignment: MainAxisAlignment.center,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -79,6 +119,16 @@ class PdfPreviewScreen extends StatelessWidget {
         title: const Text('معاينة PDF', style: TextStyle(color: Colors.white)),
         backgroundColor: AppConstants.primaryColor,
         actions: [
+          if (imageUrl != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              child: TextButton.icon(
+                style: TextButton.styleFrom(foregroundColor: Colors.white),
+                onPressed: () => _viewImageDialog(context, imageUrl!),
+                icon: const Icon(Icons.image_outlined, color: Colors.white),
+                label: const Text('عرض الصورة'),
+              ),
+            ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8.0),
             child: TextButton.icon(

--- a/lib/pages/engineer/meeting_logs_page.dart
+++ b/lib/pages/engineer/meeting_logs_page.dart
@@ -1169,12 +1169,14 @@ class _MeetingLogsPageState extends State<MeetingLogsPage> with TickerProviderSt
   }
 
   void _openPdfPreview(
-      Uint8List pdfBytes, String fileName, String text, String? link) {
+      Uint8List pdfBytes, String fileName, String text, String? link,
+      {String? imageUrl}) {
     Navigator.of(context).pushNamed('/pdf_preview', arguments: {
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
       'link': link,
+      'image': imageUrl,
     });
   }
 

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -3920,6 +3920,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         fileName,
         'الرجاء الإطلاع على تقرير ${isTestSection ? "الاختبار" : "المرحلة"}: $name لمشروع $projectName.',
         link,
+        imageUrl: isTestSection ? testImageUrl : null,
       );
 
     } catch (e) {
@@ -3952,13 +3953,15 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
   }
 
   void _openPdfPreview(
-      Uint8List pdfBytes, String fileName, String text, String? link) {
+      Uint8List pdfBytes, String fileName, String text, String? link,
+      {String? imageUrl}) {
     Navigator.of(context).pushNamed('/pdf_preview', arguments: {
       'bytes': pdfBytes,
       'fileName': fileName,
       'text': text,
       'link': link,
       'phone': _clientPhone,
+      'image': imageUrl,
     });
   }
 


### PR DESCRIPTION
## Summary
- add optional imageUrl parameter to PdfPreviewScreen
- show an image button in the PDF preview app bar
- add helper dialog to display the image
- pass image URL in `/pdf_preview` route and openPdfPreview helpers
- support showing linked images when generating test PDFs

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa48455fc832a896867afa712c800