### PR TITLE
Remove image previews from PDF reports

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -1169,13 +1169,6 @@
                 child: pw.Column(
                   crossAxisAlignment: pw.CrossAxisAlignment.end,
                   children: [
-                    if (fetchedImages[urls[i]] != null)
-                      pw.Image(
-                        fetchedImages[urls[i]]!,
-                        width: 80,
-                        height: 80,
-                        fit: pw.BoxFit.cover,
-                      ),
                     pw.UrlLink(
                       destination: urls[i],
                       child: pw.Text(
@@ -1398,13 +1391,6 @@
                 ),
               ),
               pw.SizedBox(height: 10),
-              if (fetchedImages[imgUrl] != null)
-                pw.Image(
-                  fetchedImages[imgUrl]!,
-                  width: 80,
-                  height: 80,
-                  fit: pw.BoxFit.cover,
-                ),
               pw.UrlLink(
                 destination: imgUrl,
                 child: pw.Text(
@@ -1965,13 +1951,6 @@
               pw.Column(
                 crossAxisAlignment: pw.CrossAxisAlignment.end,
                 children: [
-                  if (images[url] != null)
-                    pw.Image(
-                      images[url]!,
-                      width: 80,
-                      height: 80,
-                      fit: pw.BoxFit.cover,
-                    ),
                   pw.UrlLink(
                     destination: url,
                     child: pw.Text(
@@ -2098,13 +2077,6 @@
               pw.Column(
                 crossAxisAlignment: pw.CrossAxisAlignment.end,
                 children: [
-                  if (images[url] != null)
-                    pw.Image(
-                      images[url]!,
-                      width: 80,
-                      height: 80,
-                      fit: pw.BoxFit.cover,
-                    ),
                   pw.UrlLink(
                     destination: url,
                     child: pw.Text(


### PR DESCRIPTION
## Summary
- omit embedded images when generating PDF reports and only show "عرض" links

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb36c9e24832a9d9c0c3e7be21c69