### PR TITLE
Fix PDF upload field name

### DIFF
--- a/lib/utils/report_storage.dart
+++ b/lib/utils/report_storage.dart
@@ -18,7 +18,7 @@ class ReportStorage {
       final uri = Uri.parse(uploadReportUrl);
       var request = http.MultipartRequest('POST', uri)
         ..files.add(http.MultipartFile.fromBytes(
-          'report_file', // اسم الحقل الذي سيتوقعه الخادم لملف PDF
+          'pdf_file', // اسم الحقل الذي يتوقعه الخادم لملف PDF
           bytes,
           filename: fileName,
           // contentType: MediaType('application', 'pdf'), // قد تحتاج لإضافة هذا إذا كان الخادم يتطلب نوع المحتوى


### PR DESCRIPTION
## Summary
- fix the multipart field name when uploading PDF files

## Testing
- `flutter test test/pdf_report_generator_test.dart` *(fails: `bash: flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fbbf36bfc832ab80d112412b98ced