### PR TITLE
Fix PDF share URL prefix

### DIFF
--- a/lib/utils/report_storage.dart
+++ b/lib/utils/report_storage.dart
@@ -37,7 +37,7 @@ class ReportStorage {
           if (path != null) {
             return path.startsWith('http')
                 ? path
-                : '${AppConstants.baseUrl}/$path';
+                : '${AppConstants.baseUrl}/reports/$path';
           }
         } catch (_) {
           // Ignore JSON parse errors and fall back to raw response


### PR DESCRIPTION
## Summary
- ensure uploaded PDF links include `reports/` prefix

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc3309b6c832aa779c6e20c6ceffd