### PR TITLE
Enhance report images and compress uploads

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -511,7 +511,9 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
                                   ? 'project_entries/${widget.projectId}/$phaseId/$imageName'
                                   : 'project_entries/${widget.projectId}/$subPhaseId/$imageName';
                               final ref = FirebaseStorage.instance.ref().child(refPath);
-                              await ref.putFile(pickedImageFile!);
+                              final bytes = await pickedImageFile!.readAsBytes();
+                              final compressed = await PdfReportGenerator.resizeImageForTest(bytes);
+                              await ref.putData(compressed);
                               finalImageUrl = await ref.getDownloadURL();
                             } catch (e) {
                               if (mounted) _showFeedbackSnackBar(stfContext, 'فشل رفع الصورة: $e', isError: true);
@@ -2699,11 +2701,9 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
                               ? 'project_entries/${widget.projectId}/$phaseId/$imageName'
                               : 'project_entries/${widget.projectId}/$subPhaseId/$imageName';
                           final ref = FirebaseStorage.instance.ref().child(refPath);
-                          if (kIsWeb) {
-                            await ref.putData(await imageFile.readAsBytes());
-                          } else {
-                            await ref.putFile(File(imageFile.path));
-                          }
+                          final bytes = await imageFile.readAsBytes();
+                          final compressed = await PdfReportGenerator.resizeImageForTest(bytes);
+                          await ref.putData(compressed);
                           final url = await ref.getDownloadURL();
                           store.add(url);
                         } catch (e) {
@@ -3112,7 +3112,9 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
                         try {
                           final refPath = 'project_tests/${widget.projectId}/$testId/${DateTime.now().millisecondsSinceEpoch}.jpg';
                           final ref = FirebaseStorage.instance.ref().child(refPath);
-                          await ref.putFile(pickedImageFile!);
+                          final bytes = await pickedImageFile!.readAsBytes();
+                          final compressed = await PdfReportGenerator.resizeImageForTest(bytes);
+                          await ref.putData(compressed);
                           finalImageUrl = await ref.getDownloadURL();
                         } catch (e) {
                           if(mounted) _showFeedbackSnackBar(stfContext, 'فشل رفع صورة الاختبار: $e', isError: true);

--- a/lib/pages/engineer/edit_phase_page.dart
+++ b/lib/pages/engineer/edit_phase_page.dart
@@ -4,6 +4,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../utils/pdf_report_generator.dart';
 
 class EditPhasePage extends StatefulWidget {
   final String projectId;
@@ -72,7 +73,10 @@ class _EditPhasePageState extends State<EditPhasePage> {
     if (_image360File != null) {
       final ref360 = FirebaseStorage.instance
           .ref('project_phases/${widget.projectId}/${widget.phaseId}_360.jpg');
-      await ref360.putFile(_image360File!);
+      final bytes = await _image360File!.readAsBytes();
+      final compressed =
+          await PdfReportGenerator.resizeImageForTest(bytes);
+      await ref360.putData(compressed);
       image360Url = await ref360.getDownloadURL();
     }
 
@@ -84,8 +88,10 @@ class _EditPhasePageState extends State<EditPhasePage> {
     if (_imageFile != null) {
       final ref = FirebaseStorage.instance
           .ref('project_phases/${widget.projectId}/${widget.phaseId}.jpg');
-
-      await ref.putFile(_imageFile!);
+      final bytes = await _imageFile!.readAsBytes();
+      final compressed =
+          await PdfReportGenerator.resizeImageForTest(bytes);
+      await ref.putData(compressed);
       imageUrl = await ref.getDownloadURL();
     }
 


### PR DESCRIPTION
## Summary
- embed images directly into generated PDF reports
- fetch and resize images when creating reports
- compress image uploads before sending to Firebase Storage

## Testing
- `dart format lib/pages/engineer/edit_phase_page.dart lib/utils/pdf_report_generator.dart lib/pages/admin/admin_project_details_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687214e400e0832ab8c16ac7e71d644d