### PR TITLE
Fix Document constructor parameters

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -410,7 +410,6 @@ import 'package:flutter/foundation.dart';
       final pdf = pw.Document(
         compress: true,
         version: PdfVersion.pdf_1_5,
-        deflateLevel: PdfDeflateLevel.max,
       );
   
       final fileName =
@@ -1872,7 +1871,6 @@ import 'package:flutter/foundation.dart';
       final pdf = pw.Document(
         compress: true,
         version: PdfVersion.pdf_1_5,
-        deflateLevel: PdfDeflateLevel.max,
       );
       final fileName =
           'simple_report_${DateFormat('yyyyMMdd_HHmmss').format(now)}.pdf';


### PR DESCRIPTION
## Summary
- drop `deflateLevel` parameter from `Document` creation in `pdf_report_generator.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687223e3a474832ab7afe734c7382ab1