### PR TITLE
Increase PDF image sizes

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -1187,8 +1187,8 @@ import 'package:flutter/foundation.dart';
       if (img != null) {
         widgets.add(
           pw.Container(
-            width: 80,
-            height: 80,
+            width: (PdfPageFormat.a4.availableWidth - 8) / 3,
+            height: (PdfPageFormat.a4.availableWidth - 8) / 3,
             decoration:
                 pw.BoxDecoration(border: pw.Border.all(color: borderColor)),
             child: pw.Image(img, fit: pw.BoxFit.cover),
@@ -1211,14 +1211,16 @@ import 'package:flutter/foundation.dart';
     );
   }
 
-    static List<pw.Widget> _buildImageLinkWidgets(
-        List<String> urls, Map<String, pw.MemoryImage> images) {
-      final widgets = <pw.Widget>[];
-      for (int i = 0; i < urls.length; i++) {
-        final img = images[urls[i]];
-        if (img != null) {
-          widgets.add(pw.Image(img, width: 80, height: 80));
-        }
+  static List<pw.Widget> _buildImageLinkWidgets(
+      List<String> urls, Map<String, pw.MemoryImage> images) {
+    final widgets = <pw.Widget>[];
+    for (int i = 0; i < urls.length; i++) {
+      final img = images[urls[i]];
+      if (img != null) {
+        widgets.add(pw.Image(img,
+            width: (PdfPageFormat.a4.availableWidth - 8) / 3,
+            height: (PdfPageFormat.a4.availableWidth - 8) / 3));
+      }
         if (i < urls.length - 1) {
           widgets.add(pw.SizedBox(width: 4));
         }


### PR DESCRIPTION
## Summary
- enlarge images in PDF grids to fill the page with three images per row

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68722b596730832a81a2cac06be2925a