### PR TITLE
Add images to part requests

### DIFF
--- a/lib/pages/engineer/request_material_page.dart
+++ b/lib/pages/engineer/request_material_page.dart
@@ -116,11 +116,13 @@ class _RequestMaterialPageState extends State<RequestMaterialPage> {
       // Collect requested items as a list of maps
       final List<Map<String, dynamic>> items = [];
       for (int i = 0; i < _materialControllers.length; i++) {
-        final name = _selectedMaterials.length > i && _selectedMaterials[i] != null
-            ? _selectedMaterials[i]!.name
+        final selected = _selectedMaterials.length > i ? _selectedMaterials[i] : null;
+        final name = selected != null
+            ? selected.name
             : _materialControllers[i].text.trim();
         final qty = int.tryParse(_quantityControllers[i].text.trim()) ?? 1;
-        items.add({'name': name, 'quantity': qty});
+        final imageUrl = selected?.imageUrl ?? '';
+        items.add({'name': name, 'quantity': qty, 'imageUrl': imageUrl});
       }
 
       await FirebaseFirestore.instance.collection('partRequests').add({


### PR DESCRIPTION
## Summary
- store image URLs when submitting material requests
- include material images in part request PDF reports

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca240c218832a87a614025af5d624