### PR TITLE
Fix report footer to show correct user role

### DIFF
--- a/lib/pages/admin/admin_attendance_report_page.dart
+++ b/lib/pages/admin/admin_attendance_report_page.dart
@@ -946,7 +946,7 @@ class _AdminAttendanceReportPageState extends State<AdminAttendanceReportPage>
             font: _arabicFont!,
             fontFallback: commonFontFallback,
             qrData: qrLink,
-            generatedByText: 'المهندس: ${FirebaseAuth.instance.currentUser?.displayName ?? ''}'),
+            generatedByText: 'المسؤول: ${FirebaseAuth.instance.currentUser?.displayName ?? ''}'),
       ),
     );
 

--- a/lib/pages/admin/admin_evaluations_page.dart
+++ b/lib/pages/admin/admin_evaluations_page.dart
@@ -1395,7 +1395,7 @@ class _AdminEvaluationsPageState extends State<AdminEvaluationsPage> {
             font: _arabicFont!,
             fontFallback: commonFontFallback,
             qrData: qrLink,
-            generatedByText: 'المهندس: ${FirebaseAuth.instance.currentUser?.displayName ?? ''}'),
+            generatedByText: 'المسؤول: ${FirebaseAuth.instance.currentUser?.displayName ?? ''}'),
       ),
     );
 

--- a/lib/pages/admin/admin_meeting_logs_page.dart
+++ b/lib/pages/admin/admin_meeting_logs_page.dart
@@ -1241,7 +1241,7 @@ class _AdminMeetingLogsPageState extends State<AdminMeetingLogsPage>
             font: _arabicFont!,
             fontFallback: commonFontFallback,
             qrData: qrLink,
-            generatedByText: 'المهندس: ${FirebaseAuth.instance.currentUser?.displayName ?? ''}'),
+            generatedByText: 'المسؤول: ${FirebaseAuth.instance.currentUser?.displayName ?? ''}'),
       ),
     );
 

--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1370,7 +1370,9 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
                         color: AppConstants.primaryColor),
                     tooltip: 'تقرير PDF',
                     onPressed: () async {
-                      final bytes = await PartRequestPdfGenerator.generate(data);
+                      final bytes = await PartRequestPdfGenerator.generate(
+                          data,
+                          generatedByRole: 'المسؤول');
                       if (!mounted) return;
                       Navigator.pushNamed(context, '/pdf_preview', arguments: {
                         'bytes': bytes,
@@ -1911,6 +1913,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
           phases: predefinedPhasesStructure,
           testsStructure: finalCommissioningTests,
           generatedBy: _currentAdminName,
+          generatedByRole: 'المسؤول',
           start: start,
           end: end,
           onProgress: (p) => progress.value = p,
@@ -1923,6 +1926,7 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
           phases: predefinedPhasesStructure,
           testsStructure: finalCommissioningTests,
           generatedBy: _currentAdminName,
+          generatedByRole: 'المسؤول',
           start: start,
           end: end,
           onProgress: (p) => progress.value = p,

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -985,6 +985,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
           phases: predefinedPhasesStructure,
           testsStructure: finalCommissioningTests,
           generatedBy: _currentEngineerName,
+          generatedByRole: 'المهندس',
           start: start,
           end: end,
           onProgress: (p) => progress.value = p,
@@ -997,6 +998,7 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
           phases: predefinedPhasesStructure,
           testsStructure: finalCommissioningTests,
           generatedBy: _currentEngineerName,
+          generatedByRole: 'المهندس',
           start: start,
           end: end,
           onProgress: (p) => progress.value = p,
@@ -3363,7 +3365,9 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
                 ),
                 TextButton(
                   onPressed: () async {
-                    final bytes = await PartRequestPdfGenerator.generate(data);
+                    final bytes = await PartRequestPdfGenerator.generate(
+                        data,
+                        generatedByRole: 'المهندس');
                     if (!mounted) return;
                     Navigator.pop(ctx);
                     Navigator.pushNamed(context, '/pdf_preview', arguments: {

--- a/lib/utils/part_request_pdf_generator.dart
+++ b/lib/utils/part_request_pdf_generator.dart
@@ -66,7 +66,8 @@ class PartRequestPdfGenerator {
     return fetched;
   }
 
-  static Future<Uint8List> generate(Map<String, dynamic> data) async {
+  static Future<Uint8List> generate(Map<String, dynamic> data,
+      {String generatedByRole = 'المهندس'}) async {
     await _loadArabicFont();
     if (_arabicFont == null) {
       throw Exception('Arabic font not available');
@@ -130,7 +131,7 @@ class PartRequestPdfGenerator {
           clientName: 'غير محدد',
         ),
         build: (context) => [
-          pw.Text('المهندس: $engineerName',
+          pw.Text('$generatedByRole: $engineerName',
               style: pw.TextStyle(
                   font: _arabicFont,
                   fontWeight: pw.FontWeight.bold,
@@ -145,7 +146,7 @@ class PartRequestPdfGenerator {
         footer: (context) => PdfStyles.buildFooter(
           context,
           font: _arabicFont!,
-          generatedByText: 'المهندس: $engineerName',
+          generatedByText: '$generatedByRole: $engineerName',
         ),
       ),
     );

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -685,10 +685,8 @@ import 'package:flutter/foundation.dart';
               fontFallback: commonFontFallback,
   
               qrData: qrLink,
-  
               generatedByText:
-  
-              'المهندس: ${generatedBy ?? 'غير محدد'}'),
+              '${generatedByRole ?? 'المهندس'}: ${generatedBy ?? 'غير محدد'}'),
   
         ),
   
@@ -713,6 +711,7 @@ import 'package:flutter/foundation.dart';
       required List<Map<String, dynamic>> phases,
       required List<Map<String, dynamic>> testsStructure,
       String? generatedBy,
+      String? generatedByRole,
       DateTime? start,
       DateTime? end,
       void Function(double progress)? onProgress,
@@ -726,6 +725,7 @@ import 'package:flutter/foundation.dart';
           phases: phases,
           testsStructure: testsStructure,
           generatedBy: generatedBy,
+          generatedByRole: generatedByRole,
           start: start,
           end: end,
           onProgress: onProgress,
@@ -740,6 +740,7 @@ import 'package:flutter/foundation.dart';
         'phases': phases,
         'testsStructure': testsStructure,
         'generatedBy': generatedBy,
+        'generatedByRole': generatedByRole,
         'start': start,
         'end': end,
       });
@@ -755,6 +756,7 @@ import 'package:flutter/foundation.dart';
         testsStructure:
             List<Map<String, dynamic>>.from(args['testsStructure'] as List),
         generatedBy: args['generatedBy'] as String?,
+        generatedByRole: args['generatedByRole'] as String?,
         start: args['start'] as DateTime?,
         end: args['end'] as DateTime?,
         lowMemory: true,


### PR DESCRIPTION
## Summary
- include `generatedByRole` in `PdfReportGenerator` and use it when generating footers
- add role parameter to part request PDF generator
- pass role info from admin and engineer pages
- update admin PDF pages to label footer with `المسؤول`

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca695fc30832abd4d7429275bc3a9