### PR TITLE
Fix delegate nullability

### DIFF
--- a/lib/pages/admin/add_project_page.dart
+++ b/lib/pages/admin/add_project_page.dart
@@ -352,7 +352,7 @@ class _AddProjectPageState extends State<AddProjectPage> {
                     onTap: widget.lockClientSelection
                         ? null
                         : () async {
-                            final result = await showSearch<QueryDocumentSnapshot>(
+                            final result = await showSearch<QueryDocumentSnapshot?>(
                               context: context,
                               delegate: ClientSearchDelegate(widget.availableClients),
                             );
@@ -400,7 +400,7 @@ class _AddProjectPageState extends State<AddProjectPage> {
   }
 }
 
-class ClientSearchDelegate extends SearchDelegate<QueryDocumentSnapshot> {
+class ClientSearchDelegate extends SearchDelegate<QueryDocumentSnapshot?> {
   final List<QueryDocumentSnapshot> clients;
 
   ClientSearchDelegate(this.clients);


### PR DESCRIPTION
## Summary
- allow null return value from client search

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687caa8b2be0832a87b2be4cc3284af7