### PR TITLE
Fix missing generatedByRole parameter

### DIFF
--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -174,23 +174,24 @@ import 'package:flutter/foundation.dart';
       return fetched;
     }
   
-    static Future<PdfReportResult> generate({
-  
+  static Future<PdfReportResult> generate({
+
       required String projectId,
-  
+
       required Map<String, dynamic>? projectData,
-  
+
       required List<Map<String, dynamic>> phases,
-  
+
       required List<Map<String, dynamic>> testsStructure,
-  
+
       String? generatedBy,
-  
+      String? generatedByRole,
+
       DateTime? start,
-  
+
       DateTime? end,
       void Function(double progress)? onProgress,
-  
+
       bool lowMemory = false,
     }) async {
       // Ensure the cache does not retain images from previous reports


### PR DESCRIPTION
## Summary
- add `generatedByRole` parameter to `PdfReportGenerator.generate`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687caf637240832aa7dd0dfc1ed766a8