### PR TITLE
Enable booking editing and deletion

### DIFF
--- a/lib/pages/common/bookings_page.dart
+++ b/lib/pages/common/bookings_page.dart
@@ -241,6 +241,153 @@ class _BookingsPageState extends State<BookingsPage> {
     }
   }
 
+  Future<void> _showEditBookingDialog(Booking booking) async {
+    final titleController = TextEditingController(text: booking.title);
+    DateTime? selectedDate = booking.date;
+    String? selectedUserId = _role == 'client'
+        ? booking.engineerId
+        : (_role == 'engineer' ? booking.clientId : null);
+    String? note = booking.note;
+
+    await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return Directionality(
+          textDirection: ui.TextDirection.rtl,
+          child: AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppConstants.borderRadius),
+            ),
+            title: const Text(
+              'تعديل الحجز',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            content: StatefulBuilder(
+              builder: (context, setState) {
+                return SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      TextField(
+                        controller: titleController,
+                        decoration: const InputDecoration(labelText: 'عنوان الحجز'),
+                      ),
+                      const SizedBox(height: AppConstants.itemSpacing),
+                      Row(
+                        children: [
+                          Text(
+                            DateFormat('yyyy/MM/dd').format(selectedDate!),
+                          ),
+                          const SizedBox(width: AppConstants.itemSpacing / 2),
+                          TextButton(
+                            onPressed: () async {
+                              final now = DateTime.now();
+                              final picked = await showDatePicker(
+                                context: context,
+                                initialDate: selectedDate!,
+                                firstDate: now,
+                                lastDate: DateTime(now.year + 1),
+                              );
+                              if (picked != null) {
+                                setState(() => selectedDate = picked);
+                              }
+                            },
+                            child: const Text('تحديد'),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: AppConstants.itemSpacing),
+                      if (_role == 'admin' || _role == 'engineer' || _role == 'client')
+                        DropdownButton<String>(
+                          value: selectedUserId,
+                          isExpanded: true,
+                          hint: Text(_role == 'client' ? 'اختر المهندس' : 'اختر المستخدم'),
+                          items: _users.map((doc) {
+                            final data = doc.data() as Map<String, dynamic>;
+                            return DropdownMenuItem(
+                              value: doc.id,
+                              child: Text(data['name'] ?? ''),
+                            );
+                          }).toList(),
+                          onChanged: (value) => setState(() => selectedUserId = value),
+                        ),
+                      const SizedBox(height: AppConstants.itemSpacing),
+                      TextField(
+                        controller: TextEditingController(text: note)
+                          ..selection = TextSelection.collapsed(offset: note?.length ?? 0),
+                        maxLines: 3,
+                        onChanged: (v) => note = v,
+                        decoration: const InputDecoration(labelText: 'ملاحظة (اختياري)'),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            actionsAlignment: MainAxisAlignment.center,
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('إلغاء'),
+              ),
+              ElevatedButton(
+                onPressed: () async {
+                  if (titleController.text.isEmpty || selectedDate == null) return;
+                  try {
+                    await _firestore.collection('bookings').doc(booking.id).update({
+                      'title': titleController.text,
+                      'date': Timestamp.fromDate(selectedDate!),
+                      'engineerId': _role == 'client'
+                          ? selectedUserId
+                          : (_role == 'engineer' ? _uid : selectedUserId),
+                      'clientId': _role == 'engineer'
+                          ? selectedUserId
+                          : (_role == 'client' ? _uid : selectedUserId),
+                      'note': note,
+                    });
+                    if (mounted) Navigator.pop(context);
+                    _showFeedbackSnackBar(context, 'تم تحديث الحجز بنجاح.', isError: false);
+                  } catch (e) {
+                    _showFeedbackSnackBar(context, 'فشل تحديث الحجز: $e', isError: true);
+                  }
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppConstants.primaryColor,
+                  foregroundColor: Colors.white,
+                ),
+                child: const Text('حفظ'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _deleteBooking(String bookingId) async {
+    try {
+      await _firestore.collection('bookings').doc(bookingId).delete();
+      _showFeedbackSnackBar(context, 'تم حذف الحجز بنجاح.', isError: false);
+    } catch (e) {
+      _showFeedbackSnackBar(context, 'فشل حذف الحجز: $e', isError: true);
+    }
+  }
+
+  void _showFeedbackSnackBar(BuildContext context, String message, {required bool isError}) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message, style: const TextStyle(color: Colors.white)),
+        backgroundColor: isError ? AppConstants.errorColor : AppConstants.successColor,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(AppConstants.borderRadius / 2)),
+        margin: const EdgeInsets.all(AppConstants.paddingMedium),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_loading) {
@@ -304,12 +451,50 @@ class _BookingsPageState extends State<BookingsPage> {
                 child: ListTile(
                   title: Text(b.title),
                   subtitle: Text(DateFormat('yyyy/MM/dd').format(b.date)),
-                  trailing: _role == 'admin' && b.status == 'pending'
-                      ? TextButton(
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (_role == 'admin' && b.status == 'pending')
+                        TextButton(
                           onPressed: () => _confirmBooking(b),
                           child: const Text('تأكيد'),
                         )
-                      : Text(b.status == 'pending' ? 'بانتظار الموافقة' : 'مؤكد'),
+                      else
+                        Text(b.status == 'pending' ? 'بانتظار الموافقة' : 'مؤكد'),
+                      if (b.createdBy == _uid)
+                        PopupMenuButton<String>(
+                          onSelected: (value) {
+                            if (value == 'edit') {
+                              _showEditBookingDialog(b);
+                            } else if (value == 'delete') {
+                              _deleteBooking(b.id);
+                            }
+                          },
+                          itemBuilder: (context) => [
+                            const PopupMenuItem(
+                              value: 'edit',
+                              child: Row(
+                                children: [
+                                  Icon(Icons.edit_outlined, color: AppConstants.infoColor, size: 20),
+                                  SizedBox(width: AppConstants.paddingSmall),
+                                  Text('تعديل'),
+                                ],
+                              ),
+                            ),
+                            const PopupMenuItem(
+                              value: 'delete',
+                              child: Row(
+                                children: [
+                                  Icon(Icons.delete_outline, color: AppConstants.deleteColor, size: 20),
+                                  SizedBox(width: AppConstants.paddingSmall),
+                                  Text('حذف', style: TextStyle(color: AppConstants.deleteColor)),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                    ],
+                  ),
                 ),
               );
             },


### PR DESCRIPTION
## Summary
- add edit and delete helpers in bookings page
- allow users to edit or delete their own booking through popup menu

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687f54d12d58832aa1528896769368d4