### PR TITLE
Add Firebase messaging service worker

### DIFF
--- a/web/firebase-messaging-sw.js
+++ b/web/firebase-messaging-sw.js
@@ -1,0 +1,24 @@
+importScripts('https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/9.22.2/firebase-messaging-compat.js');
+
+// Initialize Firebase in the service worker using the same config as the app.
+firebase.initializeApp({
+  apiKey: "AIzaSyDX_fhBTQmwm-KP8Qu2gfwFQylGuaEm4VA",
+  authDomain: "eng-system.firebaseapp.com",
+  projectId: "eng-system",
+  storageBucket: "eng-system.firebasestorage.app",
+  messagingSenderId: "526461382833",
+  appId: "1:526461382833:web:46090faa13de2d4b30f290",
+  measurementId: "G-NMMTY5PN4Y"
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  const { title, body } = payload.notification ?? {};
+  if (!title) return;
+  self.registration.showNotification(title, {
+    body: body,
+    icon: '/icons/Icon-192.png'
+  });
+});


### PR DESCRIPTION
## Summary
- support Firebase push notifications on web by adding service worker

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881ed773424832aab40ed71986538af