### PR TITLE
Switch image uploads from Firebase to server

### DIFF
--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:firebase_storage/firebase_storage.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'dart:io'; // For File
 import 'package:http/http.dart' as http;


### PR DESCRIPTION
## Summary
- route all image uploads to `/images_upload/upload_image.php`
- remove remaining `firebase_storage` imports
- update admin image uploads to use `http.MultipartRequest`
- update engineer phase editing to upload via server

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882617c93a4832ab9736569b381dd42