### PR TITLE
Disable low quality PDF generation

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1918,33 +1918,17 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
 
     try {
       PdfReportResult result;
-      try {
-        result = await PdfReportGenerator.generateWithIsolate(
-          projectId: widget.projectId,
-          projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
-          phases: predefinedPhasesStructure,
-          testsStructure: finalCommissioningTests,
-          generatedBy: _currentAdminName,
-          generatedByRole: 'المسؤول',
-          start: start,
-          end: end,
-          onProgress: (p) => progress.value = p,
-        );
-      } catch (e) {
-        // Retry with low-memory settings if initial attempt fails.
-        result = await PdfReportGenerator.generateWithIsolate(
-          projectId: widget.projectId,
-          projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
-          phases: predefinedPhasesStructure,
-          testsStructure: finalCommissioningTests,
-          generatedBy: _currentAdminName,
-          generatedByRole: 'المسؤول',
-          start: start,
-          end: end,
-          onProgress: (p) => progress.value = p,
-          lowMemory: true,
-        );
-      }
+      result = await PdfReportGenerator.generateWithIsolate(
+        projectId: widget.projectId,
+        projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
+        phases: predefinedPhasesStructure,
+        testsStructure: finalCommissioningTests,
+        generatedBy: _currentAdminName,
+        generatedByRole: 'المسؤول',
+        start: start,
+        end: end,
+        onProgress: (p) => progress.value = p,
+      );
 
       await ProgressDialog.hide(context);
       _showFeedbackSnackBar(context, 'تم إنشاء التقرير بنجاح.', isError: false);
@@ -1956,30 +1940,9 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         result.downloadUrl,
       );
     } catch (e) {
-      try {
-        progress.value = 0.0;
-        final bytes = await PdfReportGenerator.generateSimpleTables(
-          projectId: widget.projectId,
-          phases: predefinedPhasesStructure,
-          testsStructure: finalCommissioningTests,
-          start: start,
-          end: end,
-          onProgress: (p) => progress.value = p,
-          lowMemory: true,
-        );
-        await ProgressDialog.hide(context);
-        _showFeedbackSnackBar(context, 'تم إنشاء تقرير مبسط بسبب نقص الذاكرة.', isError: false);
-        _openPdfPreview(
-          bytes,
-          fileName,
-          'يرجى الإطلاع على $headerText للمشروع.',
-          null,
-        );
-      } catch (e2) {
-        await ProgressDialog.hide(context);
-        _showFeedbackSnackBar(context, 'فشل إنشاء أو مشاركة التقرير: $e2', isError: true);
-        print('Error generating daily report PDF: $e2');
-      }
+      await ProgressDialog.hide(context);
+      _showFeedbackSnackBar(context, 'فشل إنشاء أو مشاركة التقرير: $e', isError: true);
+      print('Error generating daily report PDF: $e');
     }
   }
 

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -977,33 +977,17 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
     final fileName = 'daily_report_${DateFormat('yyyyMMdd_HHmmss').format(now)}.pdf';
     try {
       PdfReportResult result;
-      try {
-        result = await PdfReportGenerator.generateWithIsolate(
-          projectId: widget.projectId,
-          projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
-          phases: predefinedPhasesStructure,
-          testsStructure: finalCommissioningTests,
-          generatedBy: _currentEngineerName,
-          generatedByRole: 'المهندس',
-          start: start,
-          end: end,
-          onProgress: (p) => progress.value = p,
-        );
-      } catch (e) {
-        // Retry with low-memory settings if initial attempt fails.
-        result = await PdfReportGenerator.generateWithIsolate(
-          projectId: widget.projectId,
-          projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
-          phases: predefinedPhasesStructure,
-          testsStructure: finalCommissioningTests,
-          generatedBy: _currentEngineerName,
-          generatedByRole: 'المهندس',
-          start: start,
-          end: end,
-          onProgress: (p) => progress.value = p,
-          lowMemory: true,
-        );
-      }
+      result = await PdfReportGenerator.generateWithIsolate(
+        projectId: widget.projectId,
+        projectData: _projectDataSnapshot?.data() as Map<String, dynamic>?,
+        phases: predefinedPhasesStructure,
+        testsStructure: finalCommissioningTests,
+        generatedBy: _currentEngineerName,
+        generatedByRole: 'المهندس',
+        start: start,
+        end: end,
+        onProgress: (p) => progress.value = p,
+      );
 
       await ProgressDialog.hide(context);
       _showFeedbackSnackBar(context, getLocalizedText('تم إنشاء التقرير بنجاح.', 'Report generated successfully.'), isError: false);
@@ -1013,36 +997,15 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         getLocalizedText('يرجى الإطلاع على التقرير للمشروع.', 'Please review the project report.'),
         result.downloadUrl,
       );
-    } catch (e) {
-      try {
-        progress.value = 0.0;
-        final bytes = await PdfReportGenerator.generateSimpleTables(
-          projectId: widget.projectId,
-          phases: predefinedPhasesStructure,
-          testsStructure: finalCommissioningTests,
-          start: start,
-          end: end,
-          onProgress: (p) => progress.value = p,
-          lowMemory: true,
-        );
+      } catch (e) {
         await ProgressDialog.hide(context);
         _showFeedbackSnackBar(
           context,
-          getLocalizedText('تم إنشاء تقرير مبسط بسبب نقص الذاكرة.', 'Generated simplified report due to low memory.'),
-          isError: false,
+          getLocalizedText('فشل إنشاء أو مشاركة التقرير: $e', 'Failed to generate or share report: $e'),
+          isError: true,
         );
-        _openPdfPreview(
-          bytes,
-          fileName,
-          getLocalizedText('يرجى الإطلاع على التقرير للمشروع.', 'Please review the project report.'),
-          null,
-        );
-      } catch (e2) {
-        await ProgressDialog.hide(context);
-        _showFeedbackSnackBar(context, getLocalizedText('فشل إنشاء أو مشاركة التقرير: $e2', 'Failed to generate or share report: $e2'), isError: true);
-        print('Error generating daily report PDF: $e2');
+        print('Error generating daily report PDF: $e');
       }
-    }
   }
 
 // --- Helper Widgets (modified to accept isArabic and getLocalizedText) ---

--- a/lib/utils/pdf_report_generator.dart
+++ b/lib/utils/pdf_report_generator.dart
@@ -760,7 +760,7 @@ import 'package:flutter/foundation.dart';
         generatedByRole: args['generatedByRole'] as String?,
         start: args['start'] as DateTime?,
         end: args['end'] as DateTime?,
-        lowMemory: true,
+        lowMemory: false,
       );
     }
   


### PR DESCRIPTION
## Summary
- prevent low memory mode in PDF isolate
- always generate reports with full design
- remove fallback that produced simplified PDF versions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a26a18cd0832a8ad5c74e307c9e53