### PR TITLE
Disable low-quality report fallback

### DIFF
--- a/lib/pages/admin/admin_project_details_page.dart
+++ b/lib/pages/admin/admin_project_details_page.dart
@@ -1956,30 +1956,9 @@ class _AdminProjectDetailsPageState extends State<AdminProjectDetailsPage> with 
         result.downloadUrl,
       );
     } catch (e) {
-      try {
-        progress.value = 0.0;
-        final bytes = await PdfReportGenerator.generateSimpleTables(
-          projectId: widget.projectId,
-          phases: predefinedPhasesStructure,
-          testsStructure: finalCommissioningTests,
-          start: start,
-          end: end,
-          onProgress: (p) => progress.value = p,
-          lowMemory: true,
-        );
-        await ProgressDialog.hide(context);
-        _showFeedbackSnackBar(context, 'تم إنشاء تقرير مبسط بسبب نقص الذاكرة.', isError: false);
-        _openPdfPreview(
-          bytes,
-          fileName,
-          'يرجى الإطلاع على $headerText للمشروع.',
-          null,
-        );
-      } catch (e2) {
-        await ProgressDialog.hide(context);
-        _showFeedbackSnackBar(context, 'فشل إنشاء أو مشاركة التقرير: $e2', isError: true);
-        print('Error generating daily report PDF: $e2');
-      }
+      await ProgressDialog.hide(context);
+      _showFeedbackSnackBar(context, 'فشل إنشاء التقرير بسبب نقص الذاكرة.', isError: true);
+      print('Error generating daily report PDF: $e');
     }
   }
 

--- a/lib/pages/engineer/project_details_page.dart
+++ b/lib/pages/engineer/project_details_page.dart
@@ -1014,34 +1014,13 @@ class _ProjectDetailsPageState extends State<ProjectDetailsPage> with TickerProv
         result.downloadUrl,
       );
     } catch (e) {
-      try {
-        progress.value = 0.0;
-        final bytes = await PdfReportGenerator.generateSimpleTables(
-          projectId: widget.projectId,
-          phases: predefinedPhasesStructure,
-          testsStructure: finalCommissioningTests,
-          start: start,
-          end: end,
-          onProgress: (p) => progress.value = p,
-          lowMemory: true,
-        );
-        await ProgressDialog.hide(context);
-        _showFeedbackSnackBar(
-          context,
-          getLocalizedText('تم إنشاء تقرير مبسط بسبب نقص الذاكرة.', 'Generated simplified report due to low memory.'),
-          isError: false,
-        );
-        _openPdfPreview(
-          bytes,
-          fileName,
-          getLocalizedText('يرجى الإطلاع على التقرير للمشروع.', 'Please review the project report.'),
-          null,
-        );
-      } catch (e2) {
-        await ProgressDialog.hide(context);
-        _showFeedbackSnackBar(context, getLocalizedText('فشل إنشاء أو مشاركة التقرير: $e2', 'Failed to generate or share report: $e2'), isError: true);
-        print('Error generating daily report PDF: $e2');
-      }
+      await ProgressDialog.hide(context);
+      _showFeedbackSnackBar(
+        context,
+        getLocalizedText('فشل إنشاء التقرير بسبب نقص الذاكرة.', 'Failed to generate report due to low memory.'),
+        isError: true,
+      );
+      print('Error generating daily report PDF: $e');
     }
   }
 


### PR DESCRIPTION
## Summary
- remove simplified PDF generation fallback when memory is low
- notify the user if report creation fails due to low memory

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bb2127130832a8932131c8141b80a