### PR TITLE
feat: offload heavy reports

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "firebase-admin": "^11.10.1",
-        "firebase-functions": "^4.3.0"
+        "firebase-functions": "^4.3.0",
+        "axios": "^1.6.8",
+        "pdfkit": "^0.15.0"
       },
       "devDependencies": {
         "firebase-functions-test": "^3.1.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,9 @@
   },
   "dependencies": {
     "firebase-admin": "^11.10.1",
-    "firebase-functions": "^4.3.0"
+    "firebase-functions": "^4.3.0",
+    "axios": "^1.6.8",
+    "pdfkit": "^0.15.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0"


### PR DESCRIPTION
## Summary
- clear cached PDF images after rendering pages to free memory
- stream PDF images lazily and add backend fallback for large image sets
- add cloud function and dependencies to build PDF reports server-side

## Testing
- `npm test` *(fails: Missing script "test")*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3812f4f0832abdee167d8a73b269